### PR TITLE
Update .travis.yml to use thernon-deprecated version of rustup.sh.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 install:
-  - curl http://www.rust-lang.org/rustup.sh | sudo sh -
+  - curl https://static.rust-lang.org/rustup.sh | sudo sh -
 script:
   - cargo build --verbose
   - cargo test --verbose


### PR DESCRIPTION
The current .travis.yml tries to use the one on www.rust-lang.org, instead of the one on static.rust-lang.org. This fixes that.
