### PR TITLE
Fix #20 (Compile errors with latest rustc)

### DIFF
--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -420,8 +420,8 @@ impl PredBuilder {
     /// Validates that a version predicate can be created given the present
     /// information.
     fn build(&self) -> Result<Predicate, ReqParseError> {
-        let op = match self.op.clone() {
-            Some(x) => x,
+        let op = match self.op {
+            Some(ref x) => x.clone(),
             None => return Err(OpRequired),
         };
 


### PR DESCRIPTION
Fix #20.
- `ReqParseError` now derives `Copy` to silence a compiler warning.
- All comparison functions on `Predicate` now borrow self.
  This was causing errors in `Predicate.matches()`, where `self` was being moved while it was borrowed.
- `LexState` now derives `Copy` because otherwise it is moved out of its `Lexer` in the `next!` macro (line 523).
- In `PredBuilder.build()`, `PredBuilder.op` is now cloned if it is not `None`.
