### PR TITLE
Fix mismatched type

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -79,7 +79,7 @@ impl Version {
         let v = parse_iter(&mut s.chars());
         match v {
             Some(v) => {
-                if v.to_string() == s {
+                if v.to_string() == s.to_string() {
                     Ok(v)
                 } else {
                     Err(IncorrectParse(v, s.to_string()))


### PR DESCRIPTION
I was trying to follow along the rust lang intro on http://doc.rust-lang.org/nightly/intro.html#tools

Tried to run the `hello_world` project, i.e with following deps info in `Cargo.toml`:

``` toml
[dependencies.semver]

git = "https://github.com/rust-lang/semver.git"
```

Then I got this following error message:

``` bash
error: mismatched types: expected `collections::string::String`, found `&str` (expected struct collections::string::String, found &-ptr)
```

Got no error when writing the deps as:

``` toml
[dependencies]

semver = "*"
```

I'm on,

``` bash
$ rustc --version
rustc 0.13.0-nightly (fac5a0767 2014-11-26 22:37:06 +0000)
$ cargo --version
cargo 0.0.1-pre-nightly (d6dbce7 2014-11-27 20:59:12 +0000)
```
