### PR TITLE
Import AsciiExt to use is_ascii

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -14,6 +14,7 @@ use std::cmp;
 use std::fmt::Show;
 use std::fmt;
 use std::hash;
+use std::ascii::AsciiExt;
 
 use self::Identifier::{Numeric, AlphaNumeric};
 use self::ParseError::{GenericFailure, IncorrectParse, NonAsciiIdentifier};


### PR DESCRIPTION
is_ascii moved to a trait. Best wishes from 31C3.
