### PR TITLE
Introduce basic property-based tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ ci = ["serde", "diesel/sqlite"]
 [dev-dependencies]
 serde_json = "1.0"
 serde_derive = "1.0"
+proptest = "0.9.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,10 @@ extern crate serde;
 #[macro_use]
 extern crate diesel;
 
+// Generative test framework
+#[cfg(test)]
+extern crate proptest;
+
 // We take the common approach of keeping our own module system private, and
 // just re-exporting the interface that we want.
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -874,4 +874,21 @@ mod tests {
             parse_error("Extra junk after valid version:  abc")
         );
     }
+    use proptest::prelude::*;
+
+    /// Regex adapted from example courtesy of DavidFichtmueller via https://github.com/semver/semver/issues/232
+    /// Note the use of {0,17} constraints on consecutive digits in order to avoid overflowing
+    /// what u64 can represent
+    const SEMVER_REGEX: &str = r"(0|[1-9][0-9]{0,17})\.(0|[1-9][0-9]{0,17})\.(0|[1-9][0-9]{0,17})(-(0|[1-9][0-9]{0,17}|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]{0,17}|[0-9]{0,17}[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?";
+    proptest! {
+        #[test]
+        fn test_round_trip_parsing_and_display(input_str in SEMVER_REGEX) {
+                let v = Version::parse(&input_str)
+                            .expect("Should successfully parse a valid semver string");
+                let serialized = v.to_string();
+                assert_eq!(input_str, serialized.as_str());
+        }
+
+
+    }
 }


### PR DESCRIPTION
The following properties are checked:

* Given arbitrary generated valid semantic version strings, `Version::parse` can successfully deserialize them
* Serializing a `Version` produces content identical to the `Version`'s parse source string.
* Many arbitrary generated semantic version ranges/requirements may be successfully parsed by `VersionReq::parse`.

Notable exceptions to the set of supported semantic version ranges discovered during property test execution, particularly relating to wildcards (the requirements for which seem rather unclear at this time) were captured in a plain-old regression unit test.