### PR TITLE
Add `VersionReq::contains_op`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,7 +209,7 @@ extern crate diesel;
 
 pub use version::Identifier::{AlphaNumeric, Numeric};
 pub use version::{Identifier, SemVerError, Version};
-pub use version_req::{ReqParseError, VersionReq};
+pub use version_req::{Op, ReqParseError, VersionReq, WildcardVersion};
 
 // SemVer-compliant versions.
 mod version;


### PR DESCRIPTION
This pull request adds a `contains_op` method for checking if a `VersionReq` contains some `Op`. It also exposes the (previously) internal `Op` and `WildcardVersion` enums for use by the crate users.

Fixes #191