### PR TITLE
Made Version::new and VersionReq::any const

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -200,7 +200,7 @@ pub type Result<T> = result::Result<T, SemVerError>;
 
 impl Version {
     /// Contructs the simple case without pre or build.
-    pub fn new(major: u64, minor: u64, patch: u64) -> Version {
+    pub const fn new(major: u64, minor: u64, patch: u64) -> Version {
         Version {
             major,
             minor,

--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -217,7 +217,7 @@ impl VersionReq {
     ///
     /// let anything = VersionReq::any();
     /// ```
-    pub fn any() -> VersionReq {
+    pub const fn any() -> VersionReq {
         VersionReq {
             ranges: vec![],
             compat: Compat::Cargo,


### PR DESCRIPTION
This makes both `Version::new()` and `VersionReq::any()` const.

This bumps the minimum version to 1.39.0 (2019-11-07), this is the version that `Vec::new()` (and thus `vec![]`) became const: https://blog.rust-lang.org/2019/11/07/Rust-1.39.0.html#more-const-fns-in-the-standard-library

Closes #200