### PR TITLE
`Version::new` should be a const fn

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -299,19 +299,19 @@ impl fmt::Display for Version {
         let mut result = format!("{}.{}.{}", self.major, self.minor, self.patch);
 
         if !self.pre.is_empty() {
-            result.push_str("-");
+            result.push('-');
             for (i, x) in self.pre.iter().enumerate() {
                 if i != 0 {
-                    result.push_str(".");
+                    result.push('.');
                 }
                 result.push_str(format!("{}", x).as_ref());
             }
         }
         if !self.build.is_empty() {
-            result.push_str("+");
+            result.push('+');
             for (i, x) in self.build.iter().enumerate() {
                 if i != 0 {
-                    result.push_str(".");
+                    result.push('.');
                 }
                 result.push_str(format!("{}", x).as_ref());
             }

--- a/src/version.rs
+++ b/src/version.rs
@@ -200,6 +200,11 @@ pub type Result<T> = result::Result<T, SemVerError>;
 
 impl Version {
     /// Contructs the simple case without pre or build.
+    ///
+    /// ```
+    /// # use semver::Version;
+    /// const FOO_VERSION: Version = Version::new(1, 2, 3);
+    /// ```
     pub const fn new(major: u64, minor: u64, patch: u64) -> Version {
         Version {
             major,

--- a/src/version.rs
+++ b/src/version.rs
@@ -200,7 +200,7 @@ pub type Result<T> = result::Result<T, SemVerError>;
 
 impl Version {
     /// Contructs the simple case without pre or build.
-    pub fn new(major: u64, minor: u64, patch: u64) -> Version {
+    pub const fn new(major: u64, minor: u64, patch: u64) -> Version {
         Version {
             major,
             minor,


### PR DESCRIPTION
We can use in the definition of a constant.

```rust
const FOO_VERSION: Version = Version::new(1, 2, 3);
```