### PR TITLE
Implement VersionReq union, intersection, and simplification

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -294,19 +294,19 @@ impl fmt::Display for Version {
         let mut result = format!("{}.{}.{}", self.major, self.minor, self.patch);
 
         if !self.pre.is_empty() {
-            result.push_str("-");
+            result.push('-');
             for (i, x) in self.pre.iter().enumerate() {
                 if i != 0 {
-                    result.push_str(".");
+                    result.push('.');
                 }
                 result.push_str(format!("{}", x).as_ref());
             }
         }
         if !self.build.is_empty() {
-            result.push_str("+");
+            result.push('+');
             for (i, x) in self.build.iter().enumerate() {
                 if i != 0 {
-                    result.push_str(".");
+                    result.push('.');
                 }
                 result.push_str(format!("{}", x).as_ref());
             }

--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -1420,6 +1420,32 @@ mod test {
         assert!(!req(">=1.0.0, <2.0.0").is_exact());
     }
 
+    #[test]
+    fn union() {
+        assert_eq!(req("=1.0.0").union(&req("=1.1.0")), req("=1.0.0 || =1.1.0"));
+        assert_eq!(req("<1.0.0").union(&req(">1.1.0")), req("<1.0.0 || >1.1.0"));
+        assert_eq!(req(">1.0.0").union(&req("<1.1.0")), req("*"));
+    }
+
+    #[test]
+    fn intersection() {
+        assert_eq!(
+            req(">1.0.0").intersection(&req("<1.1.0")),
+            req(">1.0.0, <1.1.0")
+        );
+
+        assert_eq!(
+            req(">1.0.0 || <0.5").intersection(&req(">1.2.0 || <0.4")),
+            req("<0.4 || >1.2.0")
+        );
+
+        let r = req("=1.0.0").intersection(&req("=1.1.0"));
+        assert_not_match(&r, &["1.0.0", "1.1.0"]);
+
+        let r = req("<1.0.0").intersection(&req(">1.1.0"));
+        assert_not_match(&r, &["0.9.0", "1.2.0"]);
+    }
+
     fn simplify(mut v: VersionReq) -> VersionReq {
         v.simplify();
         v

--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -624,6 +624,7 @@ impl VersionReq {
             .sort_by(|a, b| predicate_at(&a.predicates[0]).cmp(&predicate_at(&b.predicates[0])));
 
         // NOTE: we start from 2, since we're going to be looking at (n-i) and (n-i+1)
+        let n = self.ranges.len();
         for i in 2..=self.ranges.len() {
             // We need to walk backwards since we might merge some.
             let i = n - i;

--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -542,7 +542,6 @@ impl VersionReq {
                         } else {
                             // Nothing will ever match this combination.
                             drop(predicates);
-                            drop(range);
                             self.ranges.swap_remove(i);
                             has_empty = true;
                             continue 'or;
@@ -585,7 +584,6 @@ impl VersionReq {
                 if end.matches_greater_inner(predicate_at(&start)) {
                     // This predicate will never match.
                     drop(predicates);
-                    drop(range);
                     self.ranges.swap_remove(i);
                     has_empty = true;
                     continue 'or;
@@ -639,9 +637,6 @@ impl VersionReq {
             let j_start = &ranges[1].predicates[0];
             if j_start.matches_greater_inner(predicate_at(&i_end)) {
                 // [0]'s end is strictly greater than [1]'s start, so the ranges overlap.
-                drop(i_end);
-                drop(j_start);
-                drop(ranges);
                 let mut j = self.ranges.swap_remove(i + 1);
                 // Recall that .predicates[1] is the range end.
                 let i_end = &mut self.ranges[i].predicates[1];
@@ -671,9 +666,6 @@ impl VersionReq {
                 && j_start.matches_exact_inner(predicate_at(&i_end))
             {
                 // The two ranges are perfectly adjacent, so we can merge them
-                drop(i_end);
-                drop(j_start);
-                drop(ranges);
                 let mut j = self.ranges.swap_remove(i + 1);
                 // Recall that .predicates[1] is the range end.
                 let i_end = &mut self.ranges[i].predicates[1];
@@ -723,7 +715,7 @@ impl VersionReq {
     }
 }
 
-fn predicate_at<'a>(x: &'a Predicate) -> (u64, u64, u64, &'a [Identifier]) {
+fn predicate_at(x: &Predicate) -> (u64, u64, u64, &[Identifier]) {
     (x.major, x.minor, x.patch, &x.pre)
 }
 


### PR DESCRIPTION
This PR adds `VersionReq::union` and `VersionReq::intersection`, and thus fixes #170.

Since the naive implementation tends to produce fairly verbose bounds, it also adds a method that "simplifies" a `VersionReq`. It does so by first reducing each `Range` to the smallest range that matches all the range's predicates, and then merging overlapping ranges. For example, the `VersionReq`:

```
[ [1, <1.5], [1.2] ]
```

which is really

```
[ [>=1.0.0, <2.0.0, <1.5.0], [>=1.2.0,<2.0.0] ]
```

is simplified to

```
[ [>=1.2.0, <1.5.0] ]
```

I did not add automatic simplification after a call to `parse`, but that might be worthwhile.

I would love for this to have significantly more test-cases, so if you can think of any, please propose them here.

Also, if you have an idea for how to avoid panicking when trying to combine `VersionReq`s with different `compat`s, please speak up!