### PR TITLE
fix broken serde test

### DIFF
--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -81,7 +81,7 @@ fn deserialize_version() {
 fn serialize_versionreq() {
     let v = VersionReq::exact(&Version::parse("1.0.0").unwrap());
 
-    assert_eq!(serde_json::to_string(&v).unwrap(), r#""= 1.0.0""#);
+    assert_eq!(serde_json::to_string(&v).unwrap(), r#""=1.0.0""#);
 }
 
 #[test]


### PR DESCRIPTION
before: `cargo test --features ci`

  ...

  running 6 tests
  test deserialize_identifier ... ok
  test serialize_identifier ... ok
  test deserialize_version ... ok
  test serialize_version ... ok
  test serialize_versionreq ... FAILED
  test deserialize_versionreq ... ok

  failures:

  ---- serialize_versionreq stdout ----
  thread 'serialize_versionreq' panicked at 'assertion failed: `(left == right)`
    left: `"\"=1.0.0\""`,
   right: `"\"= 1.0.0\""`', tests/serde.rs:84:5
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

  failures:
      serialize_versionreq

  test result: FAILED. 5 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

Fixes: 5e87530d55cf92c33df15899354cecb736b621c0 fix tests and formatting to comply with #196

Signed-off-by: Fabian Grünbichler <f.gruenbichler@proxmox.com>