### PR TITLE
Disallow patch version digit after minor version wildcard

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -277,10 +277,12 @@ fn comparator(input: &str) -> Result<(Comparator, Position, &str), Error> {
 
     let mut pos = Position::Major;
     let (major, text) = numeric_identifier(text, pos)?;
+    let mut has_wildcard = false;
 
     let (minor, text) = if let Some(text) = text.strip_prefix('.') {
         pos = Position::Minor;
         if let Some(text) = text.strip_prefix('*') {
+            has_wildcard = true;
             if default_op {
                 op = Op::Wildcard;
             }
@@ -300,7 +302,7 @@ fn comparator(input: &str) -> Result<(Comparator, Position, &str), Error> {
                 op = Op::Wildcard;
             }
             (None, text)
-        } else if op == Op::Wildcard {
+        } else if has_wildcard {
             return Err(Error::new(ErrorKind::UnexpectedAfterWildcard));
         } else {
             let (patch, text) = numeric_identifier(text, pos)?;

--- a/tests/test_version_req.rs
+++ b/tests/test_version_req.rs
@@ -377,6 +377,18 @@ fn test_cargo3202() {
 }
 
 #[test]
+fn test_digit_after_wildcard() {
+    let err = req_err("*.1");
+    assert_to_string(err, "unexpected character after wildcard in version req");
+
+    let err = req_err("1.*.1");
+    assert_to_string(err, "unexpected character after wildcard in version req");
+
+    let err = req_err(">=1.*.1");
+    assert_to_string(err, "unexpected character after wildcard in version req");
+}
+
+#[test]
 fn test_eq_hash() {
     fn calculate_hash(value: impl Hash) -> u64 {
         let mut hasher = DefaultHasher::new();


### PR DESCRIPTION
This affects illegal reqs like the one in #171: `>=1.*.3`