### PR TITLE
Add a few tests

### DIFF
--- a/tests/test_version.rs
+++ b/tests/test_version.rs
@@ -73,6 +73,16 @@ fn test_parse() {
     };
     assert_eq!(parsed, expected);
 
+    let parsed = version("1.2.3+5build");
+    let expected = Version {
+        major: 1,
+        minor: 2,
+        patch: 3,
+        pre: Prerelease::EMPTY,
+        build: build_metadata("5build"),
+    };
+    assert_eq!(parsed, expected);
+
     let parsed = version("1.2.3-alpha1+build5");
     let expected = Version {
         major: 1,
@@ -90,6 +100,16 @@ fn test_parse() {
         patch: 3,
         pre: prerelease("1.alpha1.9"),
         build: build_metadata("build5.7.3aedf"),
+    };
+    assert_eq!(parsed, expected);
+
+    let parsed = version("1.2.3-0a.alpha1.9+05build.7.3aedf");
+    let expected = Version {
+        major: 1,
+        minor: 2,
+        patch: 3,
+        pre: prerelease("0a.alpha1.9"),
+        build: build_metadata("05build.7.3aedf"),
     };
     assert_eq!(parsed, expected);
 

--- a/tests/test_version.rs
+++ b/tests/test_version.rs
@@ -41,6 +41,9 @@ fn test_parse() {
     let err = version_err("1.2.3 abc");
     assert_to_string(err, "unexpected character ' ' after patch version number");
 
+    let err = version_err("1.2.3-01");
+    assert_to_string(err, "invalid leading zero in pre-release identifier");
+
     let parsed = version("1.2.3");
     let expected = Version::new(1, 2, 3);
     assert_eq!(parsed, expected);

--- a/tests/test_version_req.rs
+++ b/tests/test_version_req.rs
@@ -400,3 +400,22 @@ fn test_eq_hash() {
     assert!(calculate_hash(req("^1")) == calculate_hash(req("^1")));
     assert!(req("^1") != req("^2"));
 }
+
+#[test]
+fn test_parsing_pre_and_build_metadata_see_issue_217() {
+    for op in &["=", ">", ">=", "<", "<=", "~", "^"] {
+        // digit then alpha
+        req(&format!("{} 1.2.3-1a", op));
+        req(&format!("{} 1.2.3+1a", op));
+
+        // digit then alpha (leading zero)
+        req(&format!("{} 1.2.3-01a", op));
+        req(&format!("{} 1.2.3+01", op));
+
+        // multiple
+        req(&format!("{} 1.2.3-1+1", op));
+        req(&format!("{} 1.2.3-1-1+1-1-1", op));
+        req(&format!("{} 1.2.3-1a+1a", op));
+        req(&format!("{} 1.2.3-1a-1a+1a-1a-1a", op));
+    }
+}


### PR DESCRIPTION
The first commit adds some tests related to #217, that regressed in 0.12. The tests now pass on 1.0.0.

The second commit adds a test for a new parse error. I haven't checked yet if we have any legacy versions on crates.io that violate this, but the error is to spec.