### PR TITLE
Fix <I.J to not match I.J.0 prereleases

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -32,8 +32,8 @@ fn matches_impl(cmp: &Comparator, ver: &Version) -> bool {
         Op::Exact | Op::Wildcard => matches_exact(cmp, ver),
         Op::Greater => matches_greater(cmp, ver),
         Op::GreaterEq => matches_exact(cmp, ver) || matches_greater(cmp, ver),
-        Op::Less => !matches_exact(cmp, ver) && !matches_greater(cmp, ver),
-        Op::LessEq => !matches_greater(cmp, ver),
+        Op::Less => matches_less(cmp, ver),
+        Op::LessEq => matches_exact(cmp, ver) || matches_less(cmp, ver),
         Op::Tilde => matches_tilde(cmp, ver),
         Op::Caret => matches_caret(cmp, ver),
         #[cfg(no_non_exhaustive)]
@@ -85,6 +85,32 @@ fn matches_greater(cmp: &Comparator, ver: &Version) -> bool {
     }
 
     ver.pre > cmp.pre
+}
+
+fn matches_less(cmp: &Comparator, ver: &Version) -> bool {
+    if ver.major != cmp.major {
+        return ver.major < cmp.major;
+    }
+
+    match cmp.minor {
+        None => return false,
+        Some(minor) => {
+            if ver.minor != minor {
+                return ver.minor < minor;
+            }
+        }
+    }
+
+    match cmp.patch {
+        None => return false,
+        Some(patch) => {
+            if ver.patch != patch {
+                return ver.patch < patch;
+            }
+        }
+    }
+
+    ver.pre < cmp.pre
 }
 
 fn matches_tilde(cmp: &Comparator, ver: &Version) -> bool {

--- a/tests/test_version_req.rs
+++ b/tests/test_version_req.rs
@@ -80,19 +80,25 @@ pub fn test_greater_than() {
 #[test]
 pub fn test_less_than() {
     let ref r = req("< 1.0.0");
-
     assert_to_string(r, "<1.0.0");
-
     assert_match_all(r, &["0.1.0", "0.0.1"]);
     assert_match_none(r, &["1.0.0", "1.0.0-beta", "1.0.1", "0.9.9-alpha"]);
 
     let ref r = req("<= 2.1.0-alpha2");
-
     assert_match_all(r, &["2.1.0-alpha2", "2.1.0-alpha1", "2.0.0", "1.0.0"]);
     assert_match_none(
         r,
         &["2.1.0", "2.2.0-alpha1", "2.0.0-alpha2", "1.0.0-alpha2"],
     );
+
+    let ref r = req(">1.0.0-alpha, <1.0.0");
+    assert_match_all(r, &["1.0.0-beta"]);
+
+    let ref r = req(">1.0.0-alpha, <1.0");
+    assert_match_none(r, &["1.0.0-beta"]);
+
+    let ref r = req(">1.0.0-alpha, <1");
+    assert_match_none(r, &["1.0.0-beta"]);
 }
 
 #[test]


### PR DESCRIPTION
This sidesteps some mystery about what `=I.J` means in the case of prerelease versions. https://github.com/semver/semver/pull/584#pullrequestreview-671766773