### PR TITLE
Parse x and X as wildcard

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -82,7 +82,7 @@ impl FromStr for VersionReq {
 
     fn from_str(text: &str) -> Result<Self, Self::Err> {
         let text = text.trim_start_matches(' ');
-        if let Some(text) = text.strip_prefix('*') {
+        if let Some(text) = wildcard(text) {
             if text.trim_start_matches(' ').is_empty() {
                 #[cfg(not(no_const_vec_new))]
                 return Ok(VersionReq::STAR);
@@ -178,6 +178,18 @@ fn numeric_identifier(input: &str, pos: Position) -> Result<(u64, &str), Error> 
         Err(Error::new(ErrorKind::UnexpectedChar(pos, unexpected)))
     } else {
         Err(Error::new(ErrorKind::UnexpectedEnd(pos)))
+    }
+}
+
+fn wildcard(input: &str) -> Option<&str> {
+    if let Some(rest) = input.strip_prefix('*') {
+        Some(rest)
+    } else if let Some(rest) = input.strip_prefix('x') {
+        Some(rest)
+    } else if let Some(rest) = input.strip_prefix('X') {
+        Some(rest)
+    } else {
+        None
     }
 }
 
@@ -281,7 +293,7 @@ fn comparator(input: &str) -> Result<(Comparator, Position, &str), Error> {
 
     let (minor, text) = if let Some(text) = text.strip_prefix('.') {
         pos = Position::Minor;
-        if let Some(text) = text.strip_prefix('*') {
+        if let Some(text) = wildcard(text) {
             has_wildcard = true;
             if default_op {
                 op = Op::Wildcard;
@@ -297,7 +309,7 @@ fn comparator(input: &str) -> Result<(Comparator, Position, &str), Error> {
 
     let (patch, text) = if let Some(text) = text.strip_prefix('.') {
         pos = Position::Patch;
-        if let Some(text) = text.strip_prefix('*') {
+        if let Some(text) = wildcard(text) {
             if default_op {
                 op = Op::Wildcard;
             }

--- a/tests/test_version_req.rs
+++ b/tests/test_version_req.rs
@@ -266,49 +266,25 @@ pub fn test_wildcard() {
     assert_match_all(r, &["0.9.1", "2.9.0", "0.0.9", "1.0.1", "1.1.1"]);
     assert_match_none(r, &[]);
 
-    let err = req_err("x");
-    assert_to_string(
-        err,
-        "unexpected character 'x' while parsing major version number",
-    );
-
-    let err = req_err("X");
-    assert_to_string(
-        err,
-        "unexpected character 'X' while parsing major version number",
-    );
+    for s in &["x", "X"] {
+        assert_eq!(*r, req(s));
+    }
 
     let ref r = req("1.*");
     assert_match_all(r, &["1.2.0", "1.2.1", "1.1.1", "1.3.0"]);
     assert_match_none(r, &["0.0.9"]);
 
-    let err = req_err("1.x");
-    assert_to_string(
-        err,
-        "unexpected character 'x' while parsing minor version number",
-    );
-
-    let err = req_err("1.X");
-    assert_to_string(
-        err,
-        "unexpected character 'X' while parsing minor version number",
-    );
+    for s in &["1.x", "1.X", "1.*.*"] {
+        assert_eq!(*r, req(s));
+    }
 
     let ref r = req("1.2.*");
     assert_match_all(r, &["1.2.0", "1.2.2", "1.2.4"]);
     assert_match_none(r, &["1.9.0", "1.0.9", "2.0.1", "0.1.3"]);
 
-    let err = req_err("1.2.x");
-    assert_to_string(
-        err,
-        "unexpected character 'x' while parsing patch version number",
-    );
-
-    let err = req_err("1.2.X");
-    assert_to_string(
-        err,
-        "unexpected character 'X' while parsing patch version number",
-    );
+    for s in &["1.2.x", "1.2.X"] {
+        assert_eq!(*r, req(s));
+    }
 }
 
 #[test]

--- a/tests/test_version_req.rs
+++ b/tests/test_version_req.rs
@@ -264,7 +264,7 @@ pub fn test_wildcard() {
 
     let ref r = req("*");
     assert_match_all(r, &["0.9.1", "2.9.0", "0.0.9", "1.0.1", "1.1.1"]);
-    assert_match_none(r, &[]);
+    assert_match_none(r, &["1.0.0-pre"]);
 
     for s in &["x", "X"] {
         assert_eq!(*r, req(s));
@@ -272,7 +272,7 @@ pub fn test_wildcard() {
 
     let ref r = req("1.*");
     assert_match_all(r, &["1.2.0", "1.2.1", "1.1.1", "1.3.0"]);
-    assert_match_none(r, &["0.0.9"]);
+    assert_match_none(r, &["0.0.9", "1.2.0-pre"]);
 
     for s in &["1.x", "1.X", "1.*.*"] {
         assert_eq!(*r, req(s));
@@ -280,7 +280,7 @@ pub fn test_wildcard() {
 
     let ref r = req("1.2.*");
     assert_match_all(r, &["1.2.0", "1.2.2", "1.2.4"]);
-    assert_match_none(r, &["1.9.0", "1.0.9", "2.0.1", "0.1.3"]);
+    assert_match_none(r, &["1.9.0", "1.0.9", "2.0.1", "0.1.3", "1.2.2-pre"]);
 
     for s in &["1.2.x", "1.2.X"] {
         assert_eq!(*r, req(s));


### PR DESCRIPTION
For example `0.4.x` is supposed to mean the same thing as `0.4.*`. https://github.com/Arnavion/derive-error-chain/blob/ed2fafa0354b10df889cf46042651a91a02d58bf/derive-error-chain/Cargo.toml#L17