### PR TITLE
Avoid inheriting formatter flags in some Display impls

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -3,18 +3,12 @@ use core::fmt::{self, Debug, Display};
 
 impl Display for Version {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        Display::fmt(&self.major, formatter)?;
-        formatter.write_str(".")?;
-        Display::fmt(&self.minor, formatter)?;
-        formatter.write_str(".")?;
-        Display::fmt(&self.patch, formatter)?;
+        write!(formatter, "{}.{}.{}", self.major, self.minor, self.patch)?;
         if !self.pre.is_empty() {
-            formatter.write_str("-")?;
-            Display::fmt(&self.pre, formatter)?;
+            write!(formatter, "-{}", self.pre)?;
         }
         if !self.build.is_empty() {
-            formatter.write_str("+")?;
-            Display::fmt(&self.build, formatter)?;
+            write!(formatter, "+{}", self.build)?;
         }
         Ok(())
     }
@@ -29,7 +23,7 @@ impl Display for VersionReq {
             if i > 0 {
                 formatter.write_str(", ")?;
             }
-            Display::fmt(comparator, formatter)?;
+            write!(formatter, "{}", comparator)?;
         }
         Ok(())
     }
@@ -50,16 +44,13 @@ impl Display for Comparator {
             Op::__NonExhaustive => unreachable!(),
         };
         formatter.write_str(op)?;
-        Display::fmt(&self.major, formatter)?;
+        write!(formatter, "{}", self.major)?;
         if let Some(minor) = &self.minor {
-            formatter.write_str(".")?;
-            Display::fmt(minor, formatter)?;
+            write!(formatter, ".{}", minor)?;
             if let Some(patch) = &self.patch {
-                formatter.write_str(".")?;
-                Display::fmt(patch, formatter)?;
+                write!(formatter, ".{}", patch)?;
                 if !self.pre.is_empty() {
-                    formatter.write_str("-")?;
-                    Display::fmt(&self.pre, formatter)?;
+                    write!(formatter, "-{}", self.pre)?;
                 }
             } else if self.op == Op::Wildcard {
                 formatter.write_str(".*")?;
@@ -102,18 +93,12 @@ impl Debug for Version {
 
 impl Debug for Prerelease {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("Prerelease(\"")?;
-        Display::fmt(self, formatter)?;
-        formatter.write_str("\")")?;
-        Ok(())
+        write!(formatter, "Prerelease(\"{}\")", self)
     }
 }
 
 impl Debug for BuildMetadata {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("BuildMetadata(\"")?;
-        Display::fmt(self, formatter)?;
-        formatter.write_str("\")")?;
-        Ok(())
+        write!(formatter, "BuildMetadata(\"{}\")", self)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,51 +31,32 @@ impl Display for Error {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match &self.kind {
             ErrorKind::UnexpectedEnd(pos) => {
-                formatter.write_str("unexpected end of input while parsing ")?;
-                Display::fmt(pos, formatter)?;
-                Ok(())
+                write!(formatter, "unexpected end of input while parsing {}", pos)
             }
             ErrorKind::UnexpectedChar(pos, ch) => {
-                formatter.write_str("unexpected character ")?;
-                Debug::fmt(ch, formatter)?;
-                formatter.write_str(" while parsing ")?;
-                Display::fmt(pos, formatter)?;
-                Ok(())
+                write!(
+                    formatter,
+                    "unexpected character {:?} while parsing {}",
+                    ch, pos,
+                )
             }
             ErrorKind::UnexpectedCharAfter(pos, ch) => {
-                formatter.write_str("unexpected character ")?;
-                Debug::fmt(ch, formatter)?;
-                formatter.write_str(" after ")?;
-                Display::fmt(pos, formatter)?;
-                Ok(())
+                write!(formatter, "unexpected character {:?} after {}", ch, pos)
             }
             ErrorKind::ExpectedCommaFound(pos, ch) => {
-                formatter.write_str("expected comma after ")?;
-                Display::fmt(pos, formatter)?;
-                formatter.write_str(", found ")?;
-                Debug::fmt(ch, formatter)?;
-                Ok(())
+                write!(formatter, "expected comma after {}, found {:?}", pos, ch)
             }
             ErrorKind::LeadingZero(pos) => {
-                formatter.write_str("invalid leading zero in ")?;
-                Display::fmt(pos, formatter)?;
-                Ok(())
+                write!(formatter, "invalid leading zero in {}", pos)
             }
             ErrorKind::Overflow(pos) => {
-                formatter.write_str("value of ")?;
-                Display::fmt(pos, formatter)?;
-                formatter.write_str(" exceeds u64::MAX")?;
-                Ok(())
+                write!(formatter, "value of {} exceeds u64::MAX", pos)
             }
             ErrorKind::EmptySegment(pos) => {
-                formatter.write_str("empty identifier segment in ")?;
-                Display::fmt(pos, formatter)?;
-                Ok(())
+                write!(formatter, "empty identifier segment in {}", pos)
             }
             ErrorKind::IllegalCharacter(pos) => {
-                formatter.write_str("unexpected character in ")?;
-                Display::fmt(pos, formatter)?;
-                Ok(())
+                write!(formatter, "unexpected character in {}", pos)
             }
             ErrorKind::UnexpectedAfterWildcard => {
                 formatter.write_str("unexpected character after wildcard in version req")


### PR DESCRIPTION
The previous implementation would produce wrong unintentional output when formatting with alignment or padding, such as {:<15}.

```console
0              .1              .0               
```