### PR TITLE
Improve error on wildcard after another comparator

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,7 @@ pub(crate) enum ErrorKind {
     Overflow(Position),
     EmptySegment(Position),
     IllegalCharacter(Position),
-    CommaAfterWildcard(char),
+    WildcardNotTheOnlyComparator(char),
     UnexpectedAfterWildcard,
     ExcessiveComparators,
 }
@@ -59,7 +59,7 @@ impl Display for Error {
             ErrorKind::IllegalCharacter(pos) => {
                 write!(formatter, "unexpected character in {}", pos)
             }
-            ErrorKind::CommaAfterWildcard(ch) => {
+            ErrorKind::WildcardNotTheOnlyComparator(ch) => {
                 write!(
                     formatter,
                     "wildcard req ({}) must be the only comparator in the version req",

--- a/tests/test_version_req.rs
+++ b/tests/test_version_req.rs
@@ -425,6 +425,12 @@ fn test_wildcard_and_another() {
     let err = req_err("0.20.0-any, *");
     assert_to_string(
         err,
-        "unexpected character '*' while parsing major version number",
+        "wildcard req (*) must be the only comparator in the version req",
+    );
+
+    let err = req_err("0.20.0-any, *, 1.0");
+    assert_to_string(
+        err,
+        "wildcard req (*) must be the only comparator in the version req",
     );
 }


### PR DESCRIPTION
Addresses https://github.com/dtolnay/semver/pull/266#discussion_r799848870. Closes #253.

@jonhoo I gave it the same error message for `0.20.0-any, *` as for `*, 0.20.0-any` in the earlier PR.