### PR TITLE
Eliminate ptr->int->ptr casting from Identifier implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
   miri:
     name: Miri
     runs-on: ubuntu-latest
+    env:
+      MIRIFLAGS: -Zmiri-tag-raw-pointers
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@miri

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@miri
       - run: cargo miri test
+      - run: cargo miri test --target i686-unknown-linux-gnu
+      - run: cargo miri test --target mips-unknown-linux-gnu
 
   outdated:
     name: Outdated

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@miri
       - run: cargo miri test
-      - run: cargo miri test --target i686-unknown-linux-gnu
-      - run: cargo miri test --target mips-unknown-linux-gnu
+      - name: Run cargo miri test (32-bit little endian)
+        run: cargo miri test --target i686-unknown-linux-gnu
+      - name: Run cargo miri test (32-bit big endian)
+        run: cargo miri test --target mips-unknown-linux-gnu
 
   outdated:
     name: Outdated

--- a/build.rs
+++ b/build.rs
@@ -8,12 +8,6 @@ fn main() {
         None => return,
     };
 
-    if compiler < 32 {
-        // u64::from_ne_bytes.
-        // https://doc.rust-lang.org/std/primitive.u64.html#method.from_ne_bytes
-        println!("cargo:rustc-cfg=no_from_ne_bytes");
-    }
-
     if compiler < 33 {
         // Exhaustive integer patterns. On older compilers, a final `_` arm is
         // required even if every possible integer value is otherwise covered.

--- a/src/backport.rs
+++ b/src/backport.rs
@@ -14,18 +14,6 @@ impl StripPrefixExt for str {
     }
 }
 
-#[cfg(no_from_ne_bytes)] // rustc <1.32
-pub(crate) trait FromNeBytes {
-    fn from_ne_bytes(bytes: [u8; 8]) -> Self;
-}
-
-#[cfg(no_from_ne_bytes)]
-impl FromNeBytes for u64 {
-    fn from_ne_bytes(bytes: [u8; 8]) -> Self {
-        unsafe { std::mem::transmute(bytes) }
-    }
-}
-
 pub(crate) use crate::alloc::vec::Vec;
 
 #[cfg(no_alloc_crate)] // rustc <1.36


### PR DESCRIPTION
This lets us pass Miri's raw pointer tagging.