### PR TITLE
make Miri even more strict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     name: Miri
     runs-on: ubuntu-latest
     env:
-      MIRIFLAGS: -Zmiri-tag-raw-pointers
+      MIRIFLAGS: -Zmiri-strict-provenance
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@miri


### PR DESCRIPTION
`-Zmiri-strict-provenance` is even stricter than raw pointer tagging (ptr-int-ptr roundtrips give out-of-bounds pointers, not just aliasing-invalid pointers), so I figured we might as well use that.