### PR TITLE
Work around rustdoc showing private internals of associated const

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,6 +497,11 @@ impl Comparator {
 }
 
 impl Prerelease {
+    // Work around https://github.com/rust-lang/rust/issues/97933
+    #[cfg(doc)]
+    pub const EMPTY: Self = "";
+
+    #[cfg(not(doc))]
     pub const EMPTY: Self = Prerelease {
         identifier: Identifier::empty(),
     };
@@ -515,6 +520,11 @@ impl Prerelease {
 }
 
 impl BuildMetadata {
+    // Work around https://github.com/rust-lang/rust/issues/97933
+    #[cfg(doc)]
+    pub const EMPTY: Self = "";
+
+    #[cfg(not(doc))]
     pub const EMPTY: Self = BuildMetadata {
         identifier: Identifier::empty(),
     };


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/97933.

### Before:

<img width="400" src="https://user-images.githubusercontent.com/1940490/172969845-3f87f2bc-8e35-423d-b169-884ac9a0f715.png">

### After:

<img width="225" src="https://user-images.githubusercontent.com/1940490/172969701-0d24c41b-827c-4978-bbf1-92be1a7c0d7a.png">