### PR TITLE
Install precompiled xargo to speed up miri job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@miri
+      - uses: dtolnay/install@xargo
+        with:
+          bin: xargo-check
       - run: cargo miri test
       - name: Run cargo miri test (32-bit little endian)
         run: cargo miri test --target i686-unknown-linux-gnu


### PR DESCRIPTION
This speeds up the miri job in CI by 1m 37s. Previously it used to compile xargo from source on first run of `cargo miri test`.

```console
Running `"/home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/bin/cargo" "install" "xargo"` to install a recent enough xargo.
    Updating crates.io index
 Downloading crates ...
  Downloaded xargo v0.3.26
  Installing xargo v0.3.26
.....
    Finished release [optimized] target(s) in 1m 37s
  Installing /home/runner/.cargo/bin/xargo
  Installing /home/runner/.cargo/bin/xargo-check
   Installed package `xargo v0.3.26` (executables `xargo`, `xargo-check`)
```