### PR TITLE
Can use alloc from std::alloc even if there is no alloc crate

### DIFF
--- a/src/backport.rs
+++ b/src/backport.rs
@@ -18,43 +18,6 @@ pub(crate) use crate::alloc::vec::Vec;
 
 #[cfg(no_alloc_crate)] // rustc <1.36
 pub(crate) mod alloc {
+    pub use std::alloc;
     pub use std::vec;
-
-    pub mod alloc {
-        use std::mem;
-        use std::process;
-
-        #[derive(Copy, Clone)]
-        pub struct Layout {
-            size: usize,
-        }
-
-        impl Layout {
-            pub unsafe fn from_size_align_unchecked(size: usize, align: usize) -> Self {
-                assert_eq!(align, 2);
-                Layout { size }
-            }
-        }
-
-        pub unsafe fn alloc(layout: Layout) -> *mut u8 {
-            let len_u16 = (layout.size + 1) / 2;
-            let mut vec = Vec::new();
-            vec.reserve_exact(len_u16);
-            let ptr: *mut u16 = vec.as_mut_ptr();
-            mem::forget(vec);
-            ptr as *mut u8
-        }
-
-        pub unsafe fn dealloc(ptr: *mut u8, layout: Layout) {
-            let len_u16 = (layout.size + 1) / 2;
-            unsafe { Vec::from_raw_parts(ptr as *mut u16, 0, len_u16) };
-        }
-
-        pub fn handle_alloc_error(_layout: Layout) -> ! {
-            // This is unreachable because the alloc implementation above never
-            // returns null; Vec::reserve_exact would already have called std's
-            // internal handle_alloc_error.
-            process::abort();
-        }
-    }
 }


### PR DESCRIPTION
I forgot `std::alloc` stabilized many versions before `extern crate alloc`.