### PR TITLE
Check for isize overflow before Layout construction

### DIFF
--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -67,11 +67,13 @@
 // allows size_of::<Version>() == size_of::<Option<Version>>().
 
 use crate::alloc::alloc::{alloc, dealloc, handle_alloc_error, Layout};
+use core::isize;
 use core::mem;
 use core::num::{NonZeroU64, NonZeroUsize};
 use core::ptr::{self, NonNull};
 use core::slice;
 use core::str;
+use core::usize;
 
 const PTR_BYTES: usize = mem::size_of::<NonNull<u8>>();
 


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/101899. https://github.com/rust-lang/rust/pull/95295, which looks like it is going to be un-reverted, makes the following change to the error condition of `Layout::from_size_align` and thus the safety requirement of `Layout::from_size_align_unchecked`:

```diff
     /// * `size`, when rounded up to the nearest multiple of `align`,
-    ///    must not overflow (i.e., the rounded value must be less than
-    ///    or equal to `usize::MAX`).
+    ///    must not overflow isize (i.e., the rounded value must be
+    ///    less than or equal to `isize::MAX`).
```