### PR TITLE
Remove workaround for rustdoc displaying private fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ doc-scrape-examples = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
-rustdoc-args = ["--cfg", "doc_cfg", "--cfg", "semver_rustdoc_workaround"]
+rustdoc-args = ["--cfg", "doc_cfg"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,11 +497,6 @@ impl Comparator {
 }
 
 impl Prerelease {
-    // Work around https://github.com/rust-lang/rust/issues/97933
-    #[cfg(all(doc, semver_rustdoc_workaround))]
-    pub const EMPTY: Self = "";
-
-    #[cfg(not(all(doc, semver_rustdoc_workaround)))]
     pub const EMPTY: Self = Prerelease {
         identifier: Identifier::empty(),
     };
@@ -520,11 +515,6 @@ impl Prerelease {
 }
 
 impl BuildMetadata {
-    // Work around https://github.com/rust-lang/rust/issues/97933
-    #[cfg(all(doc, semver_rustdoc_workaround))]
-    pub const EMPTY: Self = "";
-
-    #[cfg(not(all(doc, semver_rustdoc_workaround)))]
     pub const EMPTY: Self = BuildMetadata {
         identifier: Identifier::empty(),
     };


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/97933 has been fixed in rustdoc, so this PR undoes #286 and #281.

### Correct rendering by old rustdoc (pre nightly-2022-04-14):

![Screenshot from 2022-12-18 09-15-48](https://user-images.githubusercontent.com/1940490/208310808-273f4ec2-3f1b-462f-90b4-976d444235ce.png)

### Rendering by buggy rustdoc:

![Screenshot from 2022-12-18 09-15-40](https://user-images.githubusercontent.com/1940490/208310803-2fb67a13-9866-44a9-8e7c-37583d1692c5.png)

### Rendering with workaround:

![Screenshot from 2022-12-18 09-17-01](https://user-images.githubusercontent.com/1940490/208310807-dc430072-0c5a-4a5a-ac8e-201bb889cddc.png)

### Good enough rendering today with workaround removed:

![Screenshot from 2022-12-18 09-17-25](https://user-images.githubusercontent.com/1940490/208310806-ae0b910a-94ee-417f-b97e-4faf82e1acbb.png)


