### PR TITLE
Add a dedicated error for parsing Version from an empty string

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@ use crate::parse::Error;
 use core::fmt::{self, Debug, Display};
 
 pub(crate) enum ErrorKind {
+    Empty,
     UnexpectedEnd(Position),
     UnexpectedChar(Position, char),
     UnexpectedCharAfter(Position, char),
@@ -31,6 +32,7 @@ impl std::error::Error for Error {}
 impl Display for Error {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match &self.kind {
+            ErrorKind::Empty => formatter.write_str("empty string, expected a semver version"),
             ErrorKind::UnexpectedEnd(pos) => {
                 write!(formatter, "unexpected end of input while parsing {}", pos)
             }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -26,6 +26,10 @@ impl FromStr for Version {
     type Err = Error;
 
     fn from_str(text: &str) -> Result<Self, Self::Err> {
+        if text.is_empty() {
+            return Err(Error::new(ErrorKind::Empty));
+        }
+
         let mut pos = Position::Major;
         let (major, text) = numeric_identifier(text, pos)?;
         let text = dot(text, pos)?;

--- a/tests/test_version.rs
+++ b/tests/test_version.rs
@@ -12,10 +12,7 @@ use semver::{BuildMetadata, Prerelease, Version};
 #[test]
 fn test_parse() {
     let err = version_err("");
-    assert_to_string(
-        err,
-        "unexpected end of input while parsing major version number",
-    );
+    assert_to_string(err, "empty string, expected a semver version");
 
     let err = version_err("  ");
     assert_to_string(


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew-core/pull/114382#issuecomment-1297979948.