### PR TITLE
Refactor Display for Comparator so there are less nested if clauses.

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -60,20 +60,25 @@ impl Display for Comparator {
             Op::__NonExhaustive => unreachable!(),
         };
         formatter.write_str(op)?;
+
         write!(formatter, "{}", self.major)?;
+
         if let Some(minor) = &self.minor {
             write!(formatter, ".{}", minor)?;
-            if let Some(patch) = &self.patch {
-                write!(formatter, ".{}", patch)?;
-                if !self.pre.is_empty() {
-                    write!(formatter, "-{}", self.pre)?;
-                }
-            } else if self.op == Op::Wildcard {
-                formatter.write_str(".*")?;
-            }
         } else if self.op == Op::Wildcard {
-            formatter.write_str(".*")?;
+            return formatter.write_str(".*");
         }
+
+        if let Some(patch) = &self.patch {
+            write!(formatter, ".{}", patch)?;
+        } else if self.op == Op::Wildcard {
+            return formatter.write_str(".*");
+        }
+
+        if !self.pre.is_empty() {
+            write!(formatter, "-{}", self.pre)?;
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
While looking at `impl Display for Comparator`, I noticed that there's a nested if statements so I refactored it to reduce the indent level.
While all tests are green, this refactored version behaves slightly differently from the original version: for example, when `self.op != Op::Wildcard && self.minor == None && self.patch == Some(_)`, the results will be different.
However, I don't think this would result to bug because the constructor of Comparator doesn't seem to make such a state.