### PR TITLE
Adding missed unit test cases

### DIFF
--- a/tests/test_identifier.rs
+++ b/tests/test_identifier.rs
@@ -43,3 +43,51 @@ fn test_eq() {
     assert_ne!(prerelease("aaaaaaaaa"), prerelease("bbbbbbbbb"));
     assert_ne!(build_metadata("1"), build_metadata("001"));
 }
+
+#[test]
+fn test_comparator() {
+    let compatator = comparator("4.4.5-44");
+    assert_to_string(compatator, "^4.4.5-44");
+
+    let compatator = comparator("2.X");
+    assert_to_string(compatator, "2.*");
+
+    let compatator = comparator("2");
+    assert_to_string(compatator, "^2");
+
+    let compatator = comparator("5.x.x");
+    assert_to_string(compatator, "5.*");
+}
+
+#[test]
+fn test_prerelease() {
+    let err = prerelease_err("88.6688.b.rrrrrrr8.b.6bbbbbbb66.66\0");
+    assert_to_string(err, "unexpected character in pre-release identifier");
+}
+
+#[test]
+fn test_comparator_err() {
+    let err = comparator_err("4.4.4-012");
+    assert_to_string(err, "invalid leading zero in pre-release identifier");
+
+    let err = comparator_err("5.4.4+4.");
+    assert_to_string(err, "empty identifier segment in build metadata");
+
+    let err = comparator_err(">");
+    assert_to_string(
+        err,
+        "unexpected end of input while parsing major version number",
+    );
+
+    let err = comparator_err("4.");
+    assert_to_string(
+        err,
+        "unexpected end of input while parsing minor version number",
+    );
+
+    let err = comparator_err("4.*.");
+    assert_to_string(err, "unexpected character after wildcard in version req");
+
+    let err = comparator_err("55444.4.45-6+6.4.5.45-5644ÿ");
+    assert_to_string(err, "unexpected character 'ÿ' after build metadata");
+}

--- a/tests/test_version.rs
+++ b/tests/test_version.rs
@@ -47,6 +47,18 @@ fn test_parse() {
     let err = version_err("1.2.3-01");
     assert_to_string(err, "invalid leading zero in pre-release identifier");
 
+    let err = version_err("5.1.5++");
+    assert_to_string(err, "empty identifier segment in build metadata");
+
+    let err = version_err("07");
+    assert_to_string(err, "invalid leading zero in major version number");
+
+    let err = version_err("75774777777757777757");
+    assert_to_string(err, "value of major version number exceeds u64::MAX");
+
+    let err = version_err("8\0");
+    assert_to_string(err, "unexpected character '\\0' after major version number");
+
     let parsed = version("1.2.3");
     let expected = Version::new(1, 2, 3);
     assert_eq!(parsed, expected);

--- a/tests/test_version_req.rs
+++ b/tests/test_version_req.rs
@@ -168,6 +168,9 @@ pub fn test_multiple() {
     // https://github.com/steveklabnik/semver/issues/56
     let err = req_err("1.2.3 - 2.3.4");
     assert_to_string(err, "expected comma after patch version number, found '-'");
+
+    let err = req_err(">=2,22002222022222222,2,21,222,2,2,2,222,2,221,222,2,2,2,21,222,2,2,2,2,2,222,2222,2,2,2,222,2,222,2,222,'6");
+    assert_to_string(err, "excessive number of version comparators");
 }
 
 #[test]

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use semver::{BuildMetadata, Error, Prerelease, Version, VersionReq};
+use semver::{BuildMetadata, Comparator, Error, Prerelease, Version, VersionReq};
 use std::fmt::Display;
 
 #[cfg_attr(not(no_track_caller), track_caller)]
@@ -29,6 +29,11 @@ pub(super) fn prerelease(text: &str) -> Prerelease {
 }
 
 #[cfg_attr(not(no_track_caller), track_caller)]
+pub(super) fn prerelease_err(text: &str) -> Error {
+    Prerelease::new(text).unwrap_err()
+}
+
+#[cfg_attr(not(no_track_caller), track_caller)]
 pub(super) fn build_metadata(text: &str) -> BuildMetadata {
     BuildMetadata::new(text).unwrap()
 }
@@ -36,4 +41,14 @@ pub(super) fn build_metadata(text: &str) -> BuildMetadata {
 #[cfg_attr(not(no_track_caller), track_caller)]
 pub(super) fn assert_to_string(value: impl Display, expected: &str) {
     assert_eq!(value.to_string(), expected);
+}
+
+#[cfg_attr(not(no_track_caller), track_caller)]
+pub(super) fn comparator(text: &str) -> Comparator {
+    Comparator::parse(text).unwrap()
+}
+
+#[cfg_attr(not(no_track_caller), track_caller)]
+pub(super) fn comparator_err(text: &str) -> Error {
+    Comparator::parse(text).unwrap_err()
 }


### PR DESCRIPTION
Hi,

Thanks for your time & patience to review this PR.

We are researchers focusing on Rust unit tests. By examine the existing code, we found following unit tests can be added to improve the repo's overall unit test coverage.
We only manually changed our assert statements to make it consistent with existing macros and move the error tests to its correct location.
As for the unit tests, we found the `from_str` method for Comparator & Prerelease struct are rarely tested and there are many corner error cases in Version/VersionSeq are missed.
If you have any questions, comments or feedback, please let us know.

Thanks!
