### PR TITLE
Add BareVersion

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -1,4 +1,4 @@
-use crate::{BuildMetadata, Comparator, Op, Prerelease, Version, VersionReq};
+use crate::{BareVersion, BuildMetadata, Comparator, Op, Prerelease, Version, VersionReq};
 use core::fmt::{self, Alignment, Debug, Display, Write};
 
 impl Display for Version {
@@ -90,6 +90,27 @@ impl Display for BuildMetadata {
     }
 }
 
+impl Display for BareVersion {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let do_display = |formatter: &mut fmt::Formatter| -> fmt::Result {
+            write!(formatter, "{}.{}", self.major, self.minor)?;
+            if let Some(patch) = self.patch {
+                write!(formatter, ".{}", patch)?;
+            }
+            Ok(())
+        };
+
+        let do_len = || -> usize {
+            digits(self.major)
+                + 1
+                + digits(self.minor)
+                + self.patch.map(|patch| 1 + digits(patch)).unwrap_or(0)
+        };
+
+        pad(formatter, do_display, do_len)
+    }
+}
+
 impl Debug for Version {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut debug = formatter.debug_struct("Version");
@@ -116,6 +137,17 @@ impl Debug for Prerelease {
 impl Debug for BuildMetadata {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(formatter, "BuildMetadata(\"{}\")", self)
+    }
+}
+
+impl Debug for BareVersion {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut debug = formatter.debug_struct("BareVersion");
+        debug
+            .field("major", &self.major)
+            .field("minor", &self.minor)
+            .field("patch", &self.patch);
+        debug.finish()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,6 +377,14 @@ pub struct BuildMetadata {
     identifier: Identifier,
 }
 
+/// Bare version number as used by the [`rust-version` field](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field) in `Cargo.toml`.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct BareVersion {
+    pub major: u64,
+    pub minor: u64,
+    pub patch: Option<u64>,
+}
+
 impl Version {
     /// Create `Version` with an empty pre-release and build metadata.
     ///
@@ -430,6 +438,52 @@ impl Version {
     /// - `23456789999999999999.0.0` &mdash; overflow of a u64.
     pub fn parse(text: &str) -> Result<Self, Error> {
         Version::from_str(text)
+    }
+}
+
+impl BareVersion {
+    /// Create `BareVersion`.
+    ///
+    /// Equivalent to:
+    ///
+    /// ```
+    /// # use semver::{BareVersion, BuildMetadata, Prerelease};
+    /// #
+    /// # const fn new(major: u64, minor: u64, patch: Option<u64>) -> BareVersion {
+    /// BareVersion {
+    ///     major,
+    ///     minor,
+    ///     patch,
+    /// }
+    /// # }
+    /// ```
+    pub const fn new(major: u64, minor: u64, patch: Option<u64>) -> Self {
+        BareVersion {
+            major,
+            minor,
+            patch,
+        }
+    }
+
+    /// Create `BareVersion` by parsing from string representation.
+    ///
+    /// # Errors
+    ///
+    /// Possible reasons for the parse to fail include:
+    ///
+    /// - `1` &mdash; too few numeric components. A bare version must have
+    ///   at least two.
+    ///
+    /// - `1.0.01` &mdash; a numeric component has a leading zero.
+    ///
+    /// - `1.0.unknown` &mdash; unexpected character in one of the components.
+    ///
+    /// - `1.0.0-alpha` &mdash; pre-release and build metadata are not supported
+    ///   by bare versions. If you want to represent them, use [`Version`] instead.
+    ///
+    /// - `23456789999999999999.0.0` &mdash; overflow of a u64.
+    pub fn parse(text: &str) -> Result<Self, Error> {
+        BareVersion::from_str(text)
     }
 }
 

--- a/tests/test_bare_version.rs
+++ b/tests/test_bare_version.rs
@@ -1,0 +1,110 @@
+mod util;
+
+use crate::util::*;
+use semver::BareVersion;
+
+#[test]
+fn test_parse() {
+    let err = bare_version_err("");
+    assert_to_string(err, "empty string, expected a semver version");
+
+    let err = bare_version_err("  ");
+    assert_to_string(
+        err,
+        "unexpected character ' ' while parsing major version number",
+    );
+
+    let err = bare_version_err("1");
+    assert_to_string(
+        err,
+        "unexpected end of input while parsing major version number",
+    );
+
+    let parsed = bare_version("1.2");
+    let expected = BareVersion::new(1, 2, None);
+    assert_eq!(parsed, expected);
+    let expected = BareVersion {
+        major: 1,
+        minor: 2,
+        patch: None,
+    };
+    assert_eq!(parsed, expected);
+
+    let err = bare_version_err("1.2.3-");
+    assert_to_string(err, "unexpected character '-' after patch version number");
+
+    let err = bare_version_err("a.b.c");
+    assert_to_string(
+        err,
+        "unexpected character 'a' while parsing major version number",
+    );
+
+    let parsed = bare_version("1.2.3");
+    let expected = BareVersion::new(1, 2, Some(3));
+    assert_eq!(parsed, expected);
+    let expected = BareVersion {
+        major: 1,
+        minor: 2,
+        patch: Some(3),
+    };
+    assert_eq!(parsed, expected);
+}
+
+#[test]
+fn test_eq() {
+    assert_eq!(bare_version("1.2.3"), bare_version("1.2.3"));
+}
+
+#[test]
+fn test_ne() {
+    assert_ne!(bare_version("0.0.0"), bare_version("0.0.1"));
+    assert_ne!(bare_version("0.0.0"), bare_version("0.1.0"));
+    assert_ne!(bare_version("0.0.0"), bare_version("1.0.0"));
+}
+
+#[test]
+fn test_display() {
+    assert_to_string(bare_version("1.2.3"), "1.2.3");
+}
+
+#[test]
+fn test_lt() {
+    assert!(bare_version("0.0.0") < bare_version("1.2.3"));
+    assert!(bare_version("1.0.0") < bare_version("1.2.3"));
+    assert!(bare_version("1.2.0") < bare_version("1.2.3"));
+    assert!(bare_version("1.2") < bare_version("1.2.3"));
+}
+
+#[test]
+fn test_le() {
+    assert!(bare_version("0.0.0") <= bare_version("1.2.3"));
+    assert!(bare_version("1.0.0") <= bare_version("1.2.3"));
+    assert!(bare_version("1.2.0") <= bare_version("1.2.3"));
+    assert!(bare_version("1.2") <= bare_version("1.2.3"));
+    assert!(bare_version("1.2.3") <= bare_version("1.2.3"));
+}
+
+#[test]
+fn test_gt() {
+    assert!(bare_version("1.2.3") > bare_version("0.0.0"));
+    assert!(bare_version("1.2.3") > bare_version("1.0.0"));
+    assert!(bare_version("1.2.3") > bare_version("1.2.0"));
+    assert!(bare_version("1.2.3") > bare_version("1.2"));
+}
+
+#[test]
+fn test_ge() {
+    assert!(bare_version("1.2.3") >= bare_version("0.0.0"));
+    assert!(bare_version("1.2.3") >= bare_version("1.0.0"));
+    assert!(bare_version("1.2.3") >= bare_version("1.2.0"));
+    assert!(bare_version("1.2.3") >= bare_version("1.2"));
+    assert!(bare_version("1.2.3") >= bare_version("1.2.3"));
+}
+
+#[test]
+fn test_align() {
+    let version = bare_version("1.2.3");
+    assert_eq!("1.2.3           ", format!("{:16}", version));
+    assert_eq!("*****1.2.3******", format!("{:*^16}", version));
+    assert_eq!("           1.2.3", format!("{:>16}", version));
+}

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use semver::{BuildMetadata, Error, Prerelease, Version, VersionReq};
+use semver::{BareVersion, BuildMetadata, Error, Prerelease, Version, VersionReq};
 use std::fmt::Display;
 
 #[cfg_attr(not(no_track_caller), track_caller)]
@@ -21,6 +21,16 @@ pub(super) fn req(text: &str) -> VersionReq {
 #[cfg_attr(not(no_track_caller), track_caller)]
 pub(super) fn req_err(text: &str) -> Error {
     VersionReq::parse(text).unwrap_err()
+}
+
+#[cfg_attr(not(no_track_caller), track_caller)]
+pub(super) fn bare_version(text: &str) -> BareVersion {
+    BareVersion::parse(text).unwrap()
+}
+
+#[cfg_attr(not(no_track_caller), track_caller)]
+pub(super) fn bare_version_err(text: &str) -> Error {
+    BareVersion::parse(text).unwrap_err()
 }
 
 #[cfg_attr(not(no_track_caller), track_caller)]


### PR DESCRIPTION
Rust 1.56.0 has introduced the rust-version field in Cargo.toml, which[1]:

> must be a bare version number with two or three components;
> it cannot include semver operators or pre-release identifiers.

semver::Version requires three components so it's Deserialize implementation cannot be used for bare versions.

While bare versions can be deserialized as semver::VersionReq by virtue of being a syntactic subset, it doesn't make much sense to deserialize strings that explicitly "cannot include semver operators" as a vector of comparison operators.

This commit therefore introduces a new BareVersion type to accurately represent the restrictions of the new rust-version Cargo.toml field.

Prior art includes the cargo-msrv crate which already defines its own BareVersion type.[2] The type introduced by this commit differs in that it's a struct instead of an enum since that allows easier access to the major and minor components.

[1]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field
[2]: https://github.com/foresterre/cargo-msrv/blob/v0.15.1/src/manifest/bare_version.rs#L7-L11