### PR TITLE
Add `matches_prerelease` to allow update to prerelease version if it meets Semver compatible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,17 @@ jobs:
         env:
           RUSTFLAGS: --cfg test_node_semver ${{env.RUSTFLAGS}}
 
+  mirror_node_matches_prerelease:
+    name: mirror_node_matches_prerelease
+    needs: pre_ci
+    if: needs.pre_ci.outputs.continue
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run:  cargo test --package semver --test test_matches_prerelease --features "mirror_node_matches_prerelease" 
+
   minimal:
     name: Minimal versions
     needs: pre_ci

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.31"
 
 [features]
 default = ["std"]
+mirror_node_matches_prerelease = []
 std = []
 
 [dependencies]

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -81,6 +81,12 @@ fn matches_exact_prerelease(cmp: &Comparator, ver: &Version) -> bool {
         return true;
     }
 
+    // If the comparator has a prerelease tag like =3.0.0-alpha.24,
+    // then it shoud be only exactly match 3.0.0-alpha.24.
+    if !cmp.pre.is_empty() {
+        return false;
+    }
+
     let mut lower = Comparator {
         op: Op::Less,
         ..cmp.clone()

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2,7 +2,11 @@ use crate::{Comparator, Op, Prerelease, Version, VersionReq};
 
 pub(crate) fn matches_req(req: &VersionReq, ver: &Version, prerelease_matches: bool) -> bool {
     for cmp in &req.comparators {
-        if !matches_impl(cmp, ver, prerelease_matches) {
+        if prerelease_matches {
+            if !matches_prerelease_impl(cmp, ver) {
+                return false;
+            }
+        } else if !matches_impl(cmp, ver) {
             return false;
         }
     }
@@ -24,10 +28,41 @@ pub(crate) fn matches_req(req: &VersionReq, ver: &Version, prerelease_matches: b
 }
 
 pub(crate) fn matches_comparator(cmp: &Comparator, ver: &Version) -> bool {
-    matches_impl(cmp, ver, false) && (ver.pre.is_empty() || pre_is_compatible(cmp, ver))
+    matches_impl(cmp, ver) && (ver.pre.is_empty() || pre_is_compatible(cmp, ver))
+}
+// If VersionReq missing Minor, Patch, then filling them with 0
+fn fill_partial_req(cmp: &mut Comparator) {
+    if cmp.minor.is_none() {
+        cmp.minor = Some(0);
+        cmp.patch = Some(0);
+    } else if cmp.patch.is_none() {
+        cmp.patch = Some(0);
+    }
 }
 
-fn matches_impl(cmp: &Comparator, ver: &Version, prerelease_matches: bool) -> bool {
+fn matches_prerelease_impl(cmp: &Comparator, ver: &Version) -> bool {
+    let cmp = &{
+        let mut cmp = cmp.clone();
+        match cmp.op {
+            Op::Greater | Op::GreaterEq | Op::Less | Op::LessEq => fill_partial_req(&mut cmp),
+            _ => {}
+        }
+        cmp
+    };
+    match cmp.op {
+        Op::Exact | Op::Wildcard => matches_exact_prerelease(cmp, ver),
+        Op::Greater => matches_greater(cmp, ver),
+        Op::GreaterEq => matches_exact(cmp, ver) || matches_greater(cmp, ver),
+        Op::Less => matches_less(cmp, ver),
+        Op::LessEq => matches_exact(cmp, ver) || matches_less(cmp, ver),
+        Op::Tilde => matches_tilde_prerelease(cmp, ver),
+        Op::Caret => matches_caret_prerelease(cmp, ver),
+        #[cfg(no_non_exhaustive)]
+        Op::__NonExhaustive => unreachable!(),
+    }
+}
+
+fn matches_impl(cmp: &Comparator, ver: &Version) -> bool {
     match cmp.op {
         Op::Exact | Op::Wildcard => matches_exact(cmp, ver),
         Op::Greater => matches_greater(cmp, ver),
@@ -35,15 +70,51 @@ fn matches_impl(cmp: &Comparator, ver: &Version, prerelease_matches: bool) -> bo
         Op::Less => matches_less(cmp, ver),
         Op::LessEq => matches_exact(cmp, ver) || matches_less(cmp, ver),
         Op::Tilde => matches_tilde(cmp, ver),
-        Op::Caret => {
-            if prerelease_matches {
-                return matches_caret_prerelease(cmp, ver);
-            }
-            matches_caret(cmp, ver)
-        }
+        Op::Caret => matches_caret(cmp, ver),
         #[cfg(no_non_exhaustive)]
         Op::__NonExhaustive => unreachable!(),
     }
+}
+
+fn matches_exact_prerelease(cmp: &Comparator, ver: &Version) -> bool {
+    if matches_exact(cmp, ver) {
+        return true;
+    }
+
+    let mut lower = Comparator {
+        op: Op::Less,
+        ..cmp.clone()
+    };
+    fill_partial_req(&mut lower);
+    if !matches_greater(&lower, ver) {
+        return false;
+    }
+
+    let mut upper = Comparator {
+        op: Op::Less,
+        pre: Prerelease::new("0").unwrap(),
+        ..cmp.clone()
+    };
+
+    match (upper.minor.is_some(), upper.patch.is_some()) {
+        (true, true) => {
+            upper.patch = Some(upper.patch.unwrap() + 1);
+        }
+        (true, false) => {
+            // Partial Exact VersionReq eg. =0.24
+            upper.minor = Some(upper.minor.unwrap() + 1);
+            upper.patch = Some(0);
+        }
+        (false, false) => {
+            // Partial Exact VersionReq eg. =0
+            upper.major += 1;
+            upper.minor = Some(0);
+            upper.patch = Some(0);
+        }
+        _ => {}
+    }
+
+    matches_less(&upper, ver)
 }
 
 fn matches_exact(cmp: &Comparator, ver: &Version) -> bool {
@@ -118,6 +189,39 @@ fn matches_less(cmp: &Comparator, ver: &Version) -> bool {
     ver.pre < cmp.pre
 }
 
+fn matches_tilde_prerelease(cmp: &Comparator, ver: &Version) -> bool {
+    if matches_exact(cmp, ver) {
+        return true;
+    }
+
+    let mut lower = cmp.clone();
+    fill_partial_req(&mut lower);
+    if !matches_greater(&lower, ver) {
+        return false;
+    }
+
+    let mut upper = Comparator {
+        op: Op::Less,
+        pre: Prerelease::new("0").unwrap(),
+        ..cmp.clone()
+    };
+
+    match (upper.minor.is_some(), upper.patch.is_some()) {
+        (true, _) => {
+            upper.minor = Some(upper.minor.unwrap() + 1);
+            upper.patch = Some(0);
+        }
+        (false, false) => {
+            upper.major += 1;
+            upper.minor = Some(0);
+            upper.patch = Some(0);
+        }
+        _ => {}
+    }
+
+    matches_less(&upper, ver)
+}
+
 fn matches_tilde(cmp: &Comparator, ver: &Version) -> bool {
     if ver.major != cmp.major {
         return false;
@@ -142,33 +246,47 @@ fn matches_caret_prerelease(cmp: &Comparator, ver: &Version) -> bool {
     if matches_exact(cmp, ver) {
         return true;
     }
-    if !matches_greater(cmp, ver) {
+    let mut lower = cmp.clone();
+    fill_partial_req(&mut lower);
+    if !matches_greater(&lower, ver) {
         return false;
     }
 
-    let mut pre_cmp = Comparator {
-        op: Op::LessEq,
+    let mut upper = Comparator {
+        op: Op::Less,
         pre: Prerelease::new("0").unwrap(),
         ..cmp.clone()
     };
-    let Comparator {
-        major,
-        minor,
-        patch,
-        ..
-    } = *cmp;
 
-    if major > 0 {
-        pre_cmp.major += 1;
-        pre_cmp.minor = Some(0);
-        pre_cmp.patch = Some(0);
-    } else if minor.is_some() && minor.unwrap() > 0 {
-        pre_cmp.minor = Some(minor.unwrap() + 1);
-        pre_cmp.patch = Some(0);
-    } else {
-        pre_cmp.patch = Some(patch.unwrap() + 1);
+    match (
+        upper.major > 0,
+        upper.minor.is_some(),
+        upper.patch.is_some(),
+    ) {
+        (true, _, _) | (_, false, false) => {
+            upper.major += 1;
+            upper.minor = Some(0);
+            upper.patch = Some(0);
+        }
+        (_, true, false) => {
+            upper.minor = Some(upper.minor.unwrap() + 1);
+            upper.patch = Some(0);
+        }
+        (_, true, _) if upper.minor.unwrap() > 0 => {
+            upper.minor = Some(upper.minor.unwrap() + 1);
+            upper.patch = Some(0);
+        }
+        (_, true, _) if upper.minor.unwrap() == 0 => {
+            if upper.patch.is_none() {
+                upper.patch = Some(1);
+            } else {
+                upper.patch = Some(upper.patch.unwrap() + 1);
+            }
+        }
+        _ => {}
     }
-    matches_less(&pre_cmp, ver)
+
+    matches_less(&upper, ver)
 }
 
 fn matches_caret(cmp: &Comparator, ver: &Version) -> bool {

--- a/src/eval_ext.rs
+++ b/src/eval_ext.rs
@@ -1,0 +1,269 @@
+use super::eval::{matches_exact, matches_greater, matches_less};
+use crate::{Comparator, Op, Prerelease, Version};
+
+pub(super) fn matches_prerelease_impl(cmp: &Comparator, ver: &Version) -> bool {
+    match cmp.op {
+        Op::Exact | Op::Wildcard => matches_exact_prerelease(cmp, ver),
+        Op::Greater => matches_greater(cmp, ver),
+        Op::GreaterEq => {
+            if matches_exact_prerelease(cmp, ver) {
+                return true;
+            }
+            matches_greater(cmp, ver)
+        }
+        Op::Less => matches_less(&fill_partial_req(cmp), ver),
+        Op::LessEq => {
+            if matches_exact_prerelease(cmp, ver) {
+                return true;
+            }
+            matches_less(&fill_partial_req(cmp), ver)
+        }
+        Op::Tilde => matches_tilde_prerelease(cmp, ver),
+        Op::Caret => matches_caret_prerelease(cmp, ver),
+        #[cfg(no_non_exhaustive)]
+        Op::__NonExhaustive => unreachable!(),
+    }
+}
+
+#[cfg(not(feature = "mirror_node_matches_prerelease"))]
+fn fill_partial_req(cmp: &Comparator) -> Comparator {
+    let mut cmp = cmp.clone();
+    if cmp.minor.is_none() {
+        cmp.minor = Some(0);
+        cmp.patch = Some(0);
+    } else if cmp.patch.is_none() {
+        cmp.patch = Some(0);
+    }
+    cmp
+}
+
+#[cfg(not(feature = "mirror_node_matches_prerelease"))]
+fn matches_exact_prerelease(cmp: &Comparator, ver: &Version) -> bool {
+    if matches_exact(cmp, ver) {
+        return true;
+    }
+
+    // If the comparator has a prerelease tag like =3.0.0-alpha.24,
+    // then it shoud be only exactly match 3.0.0-alpha.24.
+    if !cmp.pre.is_empty() {
+        return false;
+    }
+
+    if !matches_greater(&fill_partial_req(cmp), ver) {
+        return false;
+    }
+
+    let mut upper = Comparator {
+        op: Op::Less,
+        pre: Prerelease::new("0").unwrap(),
+        ..cmp.clone()
+    };
+
+    match (upper.minor.is_some(), upper.patch.is_some()) {
+        (true, true) => {
+            upper.patch = Some(upper.patch.unwrap() + 1);
+        }
+        (true, false) => {
+            // Partial Exact VersionReq eg. =0.24
+            upper.minor = Some(upper.minor.unwrap() + 1);
+            upper.patch = Some(0);
+        }
+        (false, false) => {
+            // Partial Exact VersionReq eg. =0
+            upper.major += 1;
+            upper.minor = Some(0);
+            upper.patch = Some(0);
+        }
+        _ => {}
+    }
+
+    matches_less(&upper, ver)
+}
+
+fn matches_tilde_prerelease(cmp: &Comparator, ver: &Version) -> bool {
+    if matches_exact(cmp, ver) {
+        return true;
+    }
+
+    if !matches_greater(&fill_partial_req(cmp), ver) {
+        return false;
+    }
+
+    let mut upper = Comparator {
+        op: Op::Less,
+        pre: Prerelease::new("0").unwrap(),
+        ..cmp.clone()
+    };
+
+    match (upper.minor.is_some(), upper.patch.is_some()) {
+        (true, _) => {
+            upper.minor = Some(upper.minor.unwrap() + 1);
+            upper.patch = Some(0);
+        }
+        (false, false) => {
+            upper.major += 1;
+            upper.minor = Some(0);
+            upper.patch = Some(0);
+        }
+        _ => {}
+    }
+
+    matches_less(&upper, ver)
+}
+
+#[cfg(not(feature = "mirror_node_matches_prerelease"))]
+fn matches_caret_prerelease(cmp: &Comparator, ver: &Version) -> bool {
+    if matches_exact(cmp, ver) {
+        return true;
+    }
+
+    if !matches_greater(&fill_partial_req(cmp), ver) {
+        return false;
+    }
+
+    let mut upper = Comparator {
+        op: Op::Less,
+        pre: Prerelease::new("0").unwrap(),
+        ..cmp.clone()
+    };
+
+    match (
+        upper.major > 0,
+        upper.minor.is_some(),
+        upper.patch.is_some(),
+    ) {
+        (true, _, _) | (_, false, false) => {
+            upper.major += 1;
+            upper.minor = Some(0);
+            upper.patch = Some(0);
+        }
+        (_, true, false) => {
+            upper.minor = Some(upper.minor.unwrap() + 1);
+            upper.patch = Some(0);
+        }
+        (_, true, _) if upper.minor.unwrap() > 0 => {
+            upper.minor = Some(upper.minor.unwrap() + 1);
+            upper.patch = Some(0);
+        }
+        (_, true, _) if upper.minor.unwrap() == 0 => {
+            if upper.patch.is_none() {
+                upper.patch = Some(1);
+            } else {
+                upper.patch = Some(upper.patch.unwrap() + 1);
+            }
+        }
+        _ => {}
+    }
+
+    matches_less(&upper, ver)
+}
+
+#[cfg(feature = "mirror_node_matches_prerelease")]
+fn fill_partial_req(cmp: &Comparator) -> Comparator {
+    let mut cmp = cmp.clone();
+    if cmp.minor.is_none() {
+        cmp.minor = Some(0);
+        cmp.patch = Some(0);
+        cmp.pre = Prerelease::new("0").unwrap();
+    } else if cmp.patch.is_none() {
+        cmp.patch = Some(0);
+        cmp.pre = Prerelease::new("0").unwrap();
+    }
+    cmp
+}
+
+#[cfg(feature = "mirror_node_matches_prerelease")]
+fn matches_exact_prerelease(cmp: &Comparator, ver: &Version) -> bool {
+    let lower = fill_partial_req(cmp);
+    if matches_exact(&lower, ver) {
+        return true;
+    }
+
+    // If the comparator has a prerelease tag like =3.0.0-alpha.24,
+    // then it shoud be only exactly match 3.0.0-alpha.24.
+    if !cmp.pre.is_empty() {
+        return false;
+    }
+
+    if !matches_greater(&lower, ver) {
+        return false;
+    }
+
+    let mut upper = Comparator {
+        op: Op::Less,
+        pre: Prerelease::new("0").unwrap(),
+        ..cmp.clone()
+    };
+
+    match (upper.minor.is_some(), upper.patch.is_some()) {
+        (true, true) => {
+            upper.patch = Some(upper.patch.unwrap() + 1);
+        }
+        (true, false) => {
+            // Partial Exact VersionReq eg. =0.24
+            upper.minor = Some(upper.minor.unwrap() + 1);
+            upper.patch = Some(0);
+        }
+        (false, false) => {
+            // Partial Exact VersionReq eg. =0
+            upper.major += 1;
+            upper.minor = Some(0);
+            upper.patch = Some(0);
+        }
+        _ => {}
+    }
+
+    matches_less(&upper, ver)
+}
+
+#[cfg(feature = "mirror_node_matches_prerelease")]
+fn matches_caret_prerelease(cmp: &Comparator, ver: &Version) -> bool {
+    let mut lower = fill_partial_req(cmp);
+    if lower.major == 0 && lower.pre.is_empty() {
+        lower.pre = Prerelease::new("0").unwrap();
+    }
+
+    if matches_exact(&lower, ver) {
+        return true;
+    }
+
+    if !matches_greater(&lower, ver) {
+        return false;
+    }
+
+    let mut upper = Comparator {
+        op: Op::Less,
+        pre: Prerelease::new("0").unwrap(),
+        ..cmp.clone()
+    };
+
+    match (
+        upper.major > 0,
+        upper.minor.is_some(),
+        upper.patch.is_some(),
+    ) {
+        (true, _, _) | (_, false, false) => {
+            upper.major += 1;
+            upper.minor = Some(0);
+            upper.patch = Some(0);
+        }
+        (_, true, false) => {
+            upper.minor = Some(upper.minor.unwrap() + 1);
+            upper.patch = Some(0);
+        }
+        (_, true, _) if upper.minor.unwrap() > 0 => {
+            upper.minor = Some(upper.minor.unwrap() + 1);
+            upper.patch = Some(0);
+        }
+        (_, true, _) if upper.minor.unwrap() == 0 => {
+            if upper.patch.is_none() {
+                upper.patch = Some(1);
+            } else {
+                upper.patch = Some(upper.patch.unwrap() + 1);
+            }
+        }
+        _ => {}
+    }
+
+    matches_less(&upper, ver)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -521,7 +521,12 @@ impl VersionReq {
     /// Evaluate whether the given `Version` satisfies the version requirement
     /// described by `self`.
     pub fn matches(&self, version: &Version) -> bool {
-        eval::matches_req(self, version)
+        eval::matches_req(self, version, false)
+    }
+
+    /// Simliar to [`Self::matches`], it allows to match any "Semver-compatible" pre-release version.
+    pub fn matches_prerelease(&self, version: &Version) -> bool {
+        eval::matches_req(self, version, true)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,7 @@ mod backport;
 mod display;
 mod error;
 mod eval;
+mod eval_ext;
 mod identifier;
 mod impls;
 mod parse;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -526,27 +526,7 @@ impl VersionReq {
 
     /// Simliar to [`Self::matches`], it allows to match any "Semver-compatible" pre-release version.
     pub fn matches_prerelease(&self, version: &Version) -> bool {
-        let req = {
-            let mut req = self.clone();
-            req.comparators = req
-                .comparators
-                .into_iter()
-                .map(|mut cmp| {
-                    // Paritial VersionReq (eg. `0.24`) needs to be filled with minor and patch,
-                    // so that we can make sure `0.24.2-pre` matches `~0.24` or `0.24`
-                    if cmp.minor.is_none() {
-                        cmp.minor = Some(0);
-                        cmp.patch = Some(0);
-                    } else if cmp.patch.is_none() {
-                        cmp.patch = Some(0);
-                    }
-                    cmp
-                })
-                .collect();
-            req
-        };
-
-        eval::matches_req(&req, version, true)
+        eval::matches_req(self, version, true)
     }
 }
 

--- a/tests/node/mod.rs
+++ b/tests/node/mod.rs
@@ -8,13 +8,36 @@ use std::process::Command;
 pub(super) struct VersionReq(semver::VersionReq);
 
 impl VersionReq {
+    #[allow(dead_code)]
     pub(super) const STAR: Self = VersionReq(semver::VersionReq::STAR);
 
+    #[allow(dead_code)]
     pub(super) fn matches(&self, version: &Version) -> bool {
         let out = Command::new("node")
             .arg("-e")
             .arg(format!(
                 "console.log(require('semver').satisfies('{}', '{}'))",
+                version,
+                self.to_string().replace(',', ""),
+            ))
+            .output()
+            .unwrap();
+        if out.stdout == b"true\n" {
+            true
+        } else if out.stdout == b"false\n" {
+            false
+        } else {
+            let s = String::from_utf8_lossy(&out.stdout) + String::from_utf8_lossy(&out.stderr);
+            panic!("unexpected output: {}", s);
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(super) fn matches_prerelease(&self, version: &Version) -> bool {
+        let out = Command::new("node")
+            .arg("-e")
+            .arg(format!(
+                "console.log(require('semver').satisfies('{}', '{}', {{includePrerelease: true}}))",
                 version,
                 self.to_string().replace(',', ""),
             ))

--- a/tests/test_matches_prerelease.rs
+++ b/tests/test_matches_prerelease.rs
@@ -127,39 +127,105 @@ fn major_caret() {
 }
 
 #[test]
+fn test_exact() {
+    // =I.J.K equivalent to >=I.J.K, <I.J.(K+1)-0
+    let ref r = req("=4.2.1");
+    assert_prerelease_match_all(r, &["4.2.1"]);
+    assert_prerelease_match_none(r, &["1.2.3", "4.2.1-pre", "4.2.2", "5.0.0"]);
+
+    // =I.J equivalent to >=I.J.0, <I.(J+1).0-0
+    let ref r = req("=4.2");
+    // Match >= 4.2.0, < 4.3.0-0
+    assert_prerelease_match_all(r, &["4.2.0", "4.2.1", "4.2.4-pre", "4.2.9"]);
+    // Not Match < 4.2.0
+    assert_prerelease_match_none(r, &["0.0.1", "2.1.2-pre", "4.0.0-pre"]);
+    // Not Match >= 4.3.0-0
+    assert_prerelease_match_none(r, &["4.3.0-0", "4.3.0", "5.0.0-0", "5.0.0"]);
+
+    // =I equivalent to >=I.0.0, <(I+1).0.0-0
+    let ref r = req("=4");
+    // Match >= 4.0.0, < 5.0.0-0
+    assert_prerelease_match_all(r, &["4.0.0", "4.2.1", "4.2.4-pre", "4.9.9"]);
+    // Not Match < 4.0.0
+    assert_prerelease_match_none(r, &["0.0.1", "2.1.2-pre", "4.0.0-pre"]);
+    // Not Match >= 5.0.0-0
+    assert_prerelease_match_none(r, &["5.0.0-0", "5.0.0", "5.0.1"]);
+
+    // =I.J.K-pre only match I.J.K-pre
+    let ref r = req("=4.2.1-0");
+    // Only exactly match 4.2.1-0
+    assert_prerelease_match_all(r, &["4.2.1-0"]);
+    // Not match others
+    assert_prerelease_match_none(r, &["1.2.3", "4.2.0", "4.2.1-1", "4.2.2", "4.3.5"]);
+}
+
+#[test]
+fn test_greater() {
+    // >I.J.K
+    let ref r = req(">4.2.1");
+    assert_prerelease_match_all(r, &["4.2.2", "5.0.0-0", "5.0.0"]);
+    assert_prerelease_match_none(r, &["0.0.0", "4.2.1-pre", "4.2.1"]);
+    // >I.J equivalent to >=I.(J+1).0-0
+    let ref r = req(">4.2");
+    assert_prerelease_match_all(r, &["4.3.0-pre", "4.3.0", "5.0.0"]);
+    assert_prerelease_match_none(r, &["0.0.0", "4.2.1"]);
+    // >I equivalent to >=(I+1).0.0-0
+    let ref r = req(">4");
+    assert_prerelease_match_all(r, &["5.0.0-0", "5.0.0-1", "5.0.0"]);
+    assert_prerelease_match_none(r, &["0.0.0", "4.2.1"]);
+}
+
+#[test]
+fn test_greater_eq() {
+    // >=I.J.K
+    let ref r = req(">=4.2.1");
+    assert_prerelease_match_all(r, &["4.2.1", "5.0.0-0", "5.0.0"]);
+    assert_prerelease_match_none(r, &["0.0.0", "4.2.1-pre"]);
+    // >=I.J equivalent to >=I.J.0
+    let ref r = req(">=4.2");
+    assert_prerelease_match_all(r, &["4.2.0", "4.2.1-pre", "4.3.0", "5.0.0"]);
+    assert_prerelease_match_none(r, &["0.0.0", "4.1.1", "4.2.0-0"]);
+    // >=I equivalent to >=I.0.0
+    let ref r = req(">=4");
+    assert_prerelease_match_all(r, &["4.0.0", "4.1.0-1", "5.0.0"]);
+    assert_prerelease_match_none(r, &["0.0.0", "4.0.0-pre"]);
+}
+
+#[test]
+fn test_less() {
+    // <I.J.K
+    let ref r = req("<4.2.1");
+    assert_prerelease_match_all(r, &["0.0.0", "4.0.0", "4.2.1-pre"]);
+    assert_prerelease_match_none(r, &["4.2.2", "5.0.0-0", "5.0.0"]);
+    // <I.J equivalent to <I.J.0
+    let ref r = req("<4.2");
+    assert_prerelease_match_all(r, &["0.0.0", "4.2.0-pre"]);
+    assert_prerelease_match_none(r, &["4.2.0", "4.3.0-pre", "4.3.0"]);
+    // <I equivalent to <I.0.0
+    let ref r = req("<4");
+    assert_prerelease_match_all(r, &["0.0.0", "4.0.0-pre"]);
+    assert_prerelease_match_none(r, &["4.0.0", "5.0.0-1", "5.0.0"]);
+}
+
+#[test]
+fn test_less_eq() {
+    // <=I.J.K
+    let ref r = req("<=4.2.1");
+    assert_prerelease_match_all(r, &["0.0.0", "4.2.1-pre", "4.2.1"]);
+    assert_prerelease_match_none(r, &["4.2.2", "5.0.0-0", "5.0.0"]);
+    // <=I.J equivalent to <I.(J+1).0-0
+    let ref r = req("<=4.2");
+    assert_prerelease_match_all(r, &["0.0.0", "4.2.0-pre"]);
+    assert_prerelease_match_none(r, &["4.3.0-0", "4.3.0", "4.4.0"]);
+    // <=I equivalent to <(I+1).0.0-0
+    let ref r = req("<=4");
+    assert_prerelease_match_all(r, &["0.0.0", "4.0.0-pre", "4.0.0"]);
+    assert_prerelease_match_none(r, &["5.0.0-1", "5.0.0"]);
+}
+
+#[test]
 fn test_tilde() {
-    let ref r = req("~0.0.24");
-    // Match >= 0.0.24, < 0.1.0-0
-    assert_prerelease_match_all(r, &["0.0.24", "0.0.25-0", "0.0.25"]);
-    // Not Match < 0.0.24
-    assert_prerelease_match_none(r, &["0.0.1", "0.0.9", "0.0.24-pre"]);
-    // Not Match >= 0.1.0-0
-    assert_prerelease_match_none(r, &["0.1.0-0", "0.1.0", "1.2.3", "2.0.0"]);
-
-    let ref r = req("~0.24");
-    // Match >= 0.24.0, < 0.25.0-0
-    assert_prerelease_match_all(r, &["0.24.0", "0.24.1-pre", "0.24.1", "0.24.9"]);
-    // Not Match < 0.24.0
-    assert_prerelease_match_none(r, &["0.0.1", "0.9.9", "0.24.0-pre"]);
-    // Not Match >= 0.25.0-0
-    assert_prerelease_match_none(r, &["0.25.0-0", "1.1.0", "1.2.3", "2.0.0"]);
-
-    let ref r = req("~1");
-    // Match >= 1.0.0, < 2.0.0-0
-    assert_prerelease_match_all(r, &["1.0.0", "1.1.0-0", "1.1.0", "1.2.3"]);
-    // Not Match < 1.0.0
-    assert_prerelease_match_none(r, &["0.0.1", "0.9.9", "1.0.0-pre"]);
-    // Not Match >= 2.0.0-0
-    assert_prerelease_match_none(r, &["2.0.0-0", "2.0.0", "2.0.1"]);
-
-    let ref r = req("~1.2");
-    // Match >= 1.2.0, < 1.3.0-0
-    assert_prerelease_match_all(r, &["1.2.0", "1.2.1", "1.2.2-pre", "1.2.9"]);
-    // Not Match < 1.2.0
-    assert_prerelease_match_none(r, &["0.0.1", "1.0.0-pre", "1.1.0-0", "1.1.0"]);
-    // Not Match >= 1.3.0-0
-    assert_prerelease_match_none(r, &["1.3.0-0", "1.3.0", "1.4.3-pre", "1.8.9", "2.0.0"]);
-
+    // ~I.J.K — equivalent to >=I.J.K, <I.(J+1).0-0
     let ref r = req("~1.2.3");
     // Match >= 1.2.3, < 1.3.0-0
     assert_prerelease_match_all(r, &["1.2.3", "1.2.4-pre", "1.2.4"]);
@@ -168,6 +234,25 @@ fn test_tilde() {
     // Not Match >= 1.3.0-0
     assert_prerelease_match_none(r, &["1.3.0-0", "1.3.0", "1.3.1-0", "1.3.1", "2.0.0"]);
 
+    // ~I.J — equivalent to >=I.J.0, <I.(J+1).0-0
+    let ref r = req("~0.24");
+    // Match >= 0.24.0, < 0.25.0-0
+    assert_prerelease_match_all(r, &["0.24.0", "0.24.1-pre", "0.24.1", "0.24.9"]);
+    // Not Match < 0.24.0
+    assert_prerelease_match_none(r, &["0.0.1", "0.9.9", "0.24.0-pre"]);
+    // Not Match >= 0.25.0-0
+    assert_prerelease_match_none(r, &["0.25.0-0", "1.1.0", "1.2.3", "2.0.0"]);
+
+    // ~I — >=I.0.0, <(I+1).0.0-0
+    let ref r = req("~1");
+    // Match >= 1.0.0, < 2.0.0-0
+    assert_prerelease_match_all(r, &["1.0.0", "1.1.0-0", "1.1.0", "1.2.3"]);
+    // Not Match < 1.0.0
+    assert_prerelease_match_none(r, &["0.0.1", "0.9.9", "1.0.0-pre"]);
+    // Not Match >= 2.0.0-0
+    assert_prerelease_match_none(r, &["2.0.0-0", "2.0.0", "2.0.1"]);
+
+    // ~I.J.K-[pre] — equivalent to >=I.J.K-[pre], <I.J.(K+1).0
     let ref r = req("~1.2.3-0");
     // Match >= 1.2.3-0, < 1.3.0-0
     assert_prerelease_match_all(r, &["1.2.3-0", "1.2.3", "1.2.4-pre", "1.2.4"]);
@@ -178,82 +263,47 @@ fn test_tilde() {
 }
 
 #[test]
-fn test_range() {
-    let ref r = req(">=1.0.0");
-    assert_prerelease_match_all(r, &["1.0.0", "1.0.1-pre", "2.0.0-0", "2.0.0"]);
-    assert_prerelease_match_none(r, &["0.9.9", "0.10.0", "1.0.0-pre.0"]);
+fn test_caret() {
+    // ^I.J.K (for I>0) — equivalent to >=I.J.K, <(I+1).0.0-0
+    let ref r = req("^1.2.3");
+    assert_prerelease_match_all(r, &["1.2.3", "1.2.4-0", "1.8.9"]);
+    assert_prerelease_match_none(r, &["0.0.9", "1.1.1-0", "1.2.3-0", "2.0.0-pre", "2.1.1"]);
 
-    let ref r = req(">=1.0.0-pre.1");
-    assert_prerelease_match_all(r, &["1.0.0-pre.1", "1.0.0", "1.0.1-pre", "2.0.0-0"]);
-    assert_prerelease_match_none(r, &["0.9.9", "0.10.0", "1.0.0-pre.0"]);
+    // ^0.J.K (for J>0) — equivalent to >=0.J.K, <0.(J+1).0-0
+    let ref r = req("^0.2.3");
+    assert_prerelease_match_all(r, &["0.2.3", "0.2.9-0", "0.2.9"]);
+    assert_prerelease_match_none(r, &["0.0.9", "0.2.3-0", "0.3.0-0", "0.3.11", "1.1.1"]);
 
-    let ref r = req("<=1.0.0");
-    assert_prerelease_match_all(r, &["0.9.9", "0.10.0", "1.0.0-pre", "1.0.0"]);
-    assert_prerelease_match_none(r, &["1.0.1", "1.0.1-pre", "1.1.0", "2.0.0-0"]);
+    // ^0.0.K — equivalent to >=0.0.K, <0.0.(K+1)-0
+    let ref r = req("^0.0.3");
+    assert_prerelease_match_all(r, &["0.0.3"]);
+    assert_prerelease_match_none(
+        r,
+        &["0.0.1", "0.0.4-0", "0.0.9", "0.3.0-0", "0.4.0-0", "1.1.1"],
+    );
 
-    let ref r = req("<=1.0.0-0");
-    assert_prerelease_match_all(r, &["0.9.9", "0.1.0", "0.10.0", "1.0.0-0"]);
-    assert_prerelease_match_none(r, &["1.0.0-pre", "1.0.1-pre", "1.1.0", "2.0.0-0"]);
+    // ^I.J (for I>0 or J>0) — equivalent to >=I.J.0, <(I+1).0.0-0)
+    let ref r = req("^1.2");
+    assert_prerelease_match_all(r, &["1.2.0", "1.9.0-0", "1.9.9"]);
+    assert_prerelease_match_none(r, &["0.0.1", "0.0.4-0", "1.2.0-0", "2.0.0-0", "4.0.1"]);
 
-    let ref r = req(">1.0.0-0,<=1.1.0-0");
-    assert_prerelease_match_all(r, &["1.0.0-pre", "1.0.0", "1.0.9", "1.1.0-0"]);
-    assert_prerelease_match_none(r, &["0.0.1", "1.0.0-0", "1.2.3-pre", "2.0.0"]);
+    // ^0.0 — equivalent to >=0.0.0, <0.1.0-0
+    let ref r = req("^0.0");
+    assert_prerelease_match_all(r, &["0.0.0", "0.0.1", "0.0.4-0"]);
+    assert_prerelease_match_none(r, &["0.1.0-0", "0.1.0", "1.1.1"]);
 
-    let ref r = req(">=1.0.0,<1.1.0-0");
-    assert_prerelease_match_all(r, &["1.0.0", "1.0.0", "1.0.9"]);
-    assert_prerelease_match_none(r, &["0.0.1", "1.0.0-pre", "1.1.0-0", "1.1.0", "2.0.0"]);
+    // ^I — equivalent to >=I.0.0, <(I+1).0.0-0
+    let ref r = req("^1");
+    assert_prerelease_match_all(r, &["1.0.0", "1.0.1", "1.0.4-0"]);
+    assert_prerelease_match_none(r, &["0.1.0-0", "0.1.0", "2.0.0-0", "3.1.2"]);
 }
 
 #[test]
-fn test_range_partial() {
-    let ref r = req(">=0.24");
-    assert_prerelease_match_all(r, &["0.24.0", "0.24.1", "2.0.0-0", "2.0.0"]);
-    assert_prerelease_match_none(r, &["0.9.9", "0.10.0", "0.24.0-pre.0"]);
-
-    let ref r = req(">=1");
-    assert_prerelease_match_all(r, &["1.0.0", "1.0.1-pre", "2.0.0-0", "2.0.0"]);
-    assert_prerelease_match_none(r, &["0.9.9", "0.10.0", "1.0.0-pre.0"]);
-
-    let ref r = req("<1");
-    assert_prerelease_match_none(r, &["1.0.0", "1.0.1-pre", "2.0.0-0", "2.0.0"]);
-    assert_prerelease_match_all(r, &["0.9.9", "0.10.0", "1.0.0-pre.0"]);
-
-    let ref r = req(">=1.1");
-    assert_prerelease_match_all(r, &["1.1.0", "1.1.1-pre", "2.0.0-0"]);
-    assert_prerelease_match_none(r, &["0.9.9", "0.10.0", "1.0.0-pre.0"]);
-
-    let ref r = req("<1.1");
-    assert_prerelease_match_none(r, &["1.1.0", "1.1.1-pre", "2.0.0-0"]);
-    assert_prerelease_match_all(r, &["0.9.9", "0.10.0", "1.0.0-pre.0"]);
-
-    let ref r = req(">1,<=1.1");
-    assert_prerelease_match_all(r, &["1.0.9", "1.1.0-0"]);
-    assert_prerelease_match_none(r, &["0.0.1", "1.0.0-0", "1.2.3-pre", "2.0.0"]);
-
-    let ref r = req(">=1.1,<2");
-    assert_prerelease_match_all(r, &["1.1.0", "1.2.9-pre", "1.2.9", "2.0.0-pre"]);
-    assert_prerelease_match_none(r, &["0.0.1", "1.0.0-pre", "1.1.0-pre"]);
-
-    let ref r = req("*");
-    assert_prerelease_match_all(r, &["0.0.1", "1.0.0", "1.2.9", "2.0.0-pre"]);
-
-    let ref r = req("^1, <=1.9");
-    assert_prerelease_match_all(r, &["1.1.1-pre", "1.1.1"]);
-    let ref r = req("^0, <=0.0.1-z0");
-    assert_prerelease_match_all(r, &["0.0.1-z0"]);
-}
-
-#[test]
-fn test_exact() {
-    let ref r = req("=4");
-    // Match >= 4.0.0, < 5.0.0-0
-    assert_prerelease_match_all(r, &["4.0.0", "4.2.1", "4.2.4-pre", "4.9.9"]);
-    // Not Match < 4.0.0
-    assert_prerelease_match_none(r, &["0.0.1", "2.1.2-pre", "4.0.0-pre"]);
-    // Not Match >= 5.0.0-0
-    assert_prerelease_match_none(r, &["5.0.0-0", "5.0.0", "5.0.1"]);
-
-    let ref r = req("=4.2");
+fn test_wildcard() {
+    // I.J.* — equivalent to =I.J
+    //
+    // =I.J equivalent to >=I.J.0, <I.(J+1).0-0
+    let ref r = req("4.2.*");
     // Match >= 4.2.0, < 4.3.0-0
     assert_prerelease_match_all(r, &["4.2.0", "4.2.1", "4.2.4-pre", "4.2.9"]);
     // Not Match < 4.2.0
@@ -261,22 +311,15 @@ fn test_exact() {
     // Not Match >= 4.3.0-0
     assert_prerelease_match_none(r, &["4.3.0-0", "4.3.0", "5.0.0-0", "5.0.0", "5.0.1"]);
 
-    let ref r = req("=4.2.1");
-    assert_prerelease_match_all(r, &["4.2.1"]);
-    assert_prerelease_match_none(r, &["1.2.3", "4.2.1-pre", "4.2.2", "5.0.0"]);
-
-    let ref r = req("=4.2.1-0");
-    // Only exactly match 4.2.1-0
-    assert_prerelease_match_all(r, &["4.2.1-0"]);
-    // Not match others
-    assert_prerelease_match_none(r, &["1.2.3", "4.2.0", "4.2.1-1", "4.2.2", "4.3.5"]);
-
-    // Speicial Case
-    let ref r = req("=0");
-    // Match >= 0.0.0, < 1.0.0-0
-    assert_prerelease_match_all(r, &["0.0.0", "0.1.1", "0.9.9"]);
-    // Not Match < 0.0.0
-    assert_prerelease_match_none(r, &["0.0.0-0", "0.0.0-pre"]);
-    // Not Match >= 1.0.0-0
-    assert_prerelease_match_none(r, &["1.0.0-0", "1.0.0", "2.0.1"]);
+    // I.* or I.*.* — equivalent to =I
+    //
+    // =I equivalent to >=I.0.0, <(I+1).0.0-0
+    for r in &[req("4.*"), req("4.*.*")] {
+        // Match >= 4.0.0, < 5.0.0-0
+        assert_prerelease_match_all(r, &["4.0.0", "4.2.1", "4.2.4-pre", "4.9.9"]);
+        // Not Match < 4.0.0
+        assert_prerelease_match_none(r, &["0.0.1", "2.1.2-pre", "4.0.0-pre"]);
+        // Not Match >= 5.0.0-0
+        assert_prerelease_match_none(r, &["5.0.0-0", "5.0.0", "5.0.1"]);
+    }
 }

--- a/tests/test_matches_prerelease.rs
+++ b/tests/test_matches_prerelease.rs
@@ -48,26 +48,51 @@ fn patch_caret() {
 
 #[test]
 fn minor_caret() {
+    let ref r = req("0.24");
+    // Match >= 0.24.0, < 0.25.0-0
+    assert_prerelease_match_all(r, &["0.24.0", "0.24.1-0", "0.24.1-pre", "0.24.1"]);
+    // Not Match < 0.24.0
+    assert_prerelease_match_none(r, &["0.1.0", "0.8.0-pre"]);
+    // Not Match >= 0.25.0-0
+    assert_prerelease_match_none(r, &["0.25.0-0", "0.25.0", "0.25.8", "2.0.0-0"]);
+
     let ref r = req("0.8.0");
-    // Match >=0.8.0, <0.9.0-0
+    // Match >= 0.8.0, < 0.9.0-0
     assert_prerelease_match_all(r, &["0.8.0", "0.8.1-0", "0.8.1-pre", "0.8.1"]);
     // Not Match <0.8.0
     assert_prerelease_match_none(r, &["0.1.0", "0.8.0-pre"]);
-    // Not Match >=0.9.0
+    // Not Match >=0.9.0-0
+    assert_prerelease_match_none(r, &["0.9.0-0", "1.0.0-pre", "2.0.0-0"]);
 
     let ref r = req("0.8.0-0");
-    // Match >=0.8.0-0, <0.9.0-0
+    // Match >= 0.8.0-0, < 0.9.0-0
     assert_prerelease_match_all(r, &["0.8.0-0", "0.8.0", "0.8.1-pre", "0.8.1"]);
-    // Not Match <0.8.0-0
+    // Not Match < 0.8.0-0
     assert_prerelease_match_none(r, &["0.1.0", "0.7.7-pre", "0.7.7"]);
-    // Not Match >=0.9.0
+    // Not Match >= 0.9.0-0
     assert_prerelease_match_none(r, &["0.9.0-0", "0.9.0", "1.0.0-pre", "2.0.0-0"]);
 }
 
 #[test]
 fn major_caret() {
+    let ref r = req("1");
+    // Match >= 1.0.0, < 2.0.0-0
+    assert_prerelease_match_all(r, &["1.2.3", "1.2.4-0", "1.2.4", "1.8.8"]);
+    // Not Match < 1.0.0
+    assert_prerelease_match_none(r, &["0.0.8", "0.9.0", "1.0.0-pre"]);
+    // Not Match >= 2.0.0-0
+    assert_prerelease_match_none(r, &["2.0.0-0", "2.0.0", "2.0.1"]);
+
+    let ref r = req("1.2");
+    // Match >= 1.2.0, < 1.3.0-0
+    assert_prerelease_match_all(r, &["1.2.3", "1.2.4-0", "1.2.4", "1.8.8"]);
+    // Not Match < 1.2.0
+    assert_prerelease_match_none(r, &["0.0.8", "0.9.0", "1.0.0-pre"]);
+    // Not Match >= 1.3.0-0
+    assert_prerelease_match_none(r, &["2.0.0-0", "2.0.0", "2.0.1"]);
+
     let ref r = req("1.2.3");
-    // Match >=1.2.3, <2.0.0-0
+    // Match >=1.2.3, < 2.0.0-0
     assert_prerelease_match_all(r, &["1.2.3", "1.2.4-0", "1.2.4", "1.8.8"]);
     // Not Match < 1.2.3
     assert_prerelease_match_none(r, &["0.8.8", "1.2.0", "1.2.3-pre"]);
@@ -75,35 +100,120 @@ fn major_caret() {
     assert_prerelease_match_none(r, &["2.0.0-0", "2.0.0", "2.0.1"]);
 
     let ref r = req("1.2.3-0");
-    // Match >=1.2.3-0, <2.0.0-0
+    // Match >= 1.2.3-0, < 2.0.0-0
     assert_prerelease_match_all(r, &["1.2.3-pre", "1.2.3", "1.2.4-0", "1.2.4"]);
     // Not Match < 1.2.3-0, >= 2.0.0-0
     assert_prerelease_match_none(r, &["1.2.0", "2.0.0-0", "2.0.0"]);
 }
 
 #[test]
-fn test_non_caret() {
-    let ref r: VersionReq = req(">=1.0.0");
+fn test_tilde() {
+    let ref r = req("~0.0.24");
+    // Match >= 0.0.24, < 0.1.0-0
+    assert_prerelease_match_all(r, &["0.0.24", "0.0.25-0", "0.0.25"]);
+    // Not Match < 0.0.24
+    assert_prerelease_match_none(r, &["0.0.1", "0.0.9", "0.0.24-pre"]);
+    // Not Match >= 0.1.0-0
+    assert_prerelease_match_none(r, &["0.1.0-0", "0.1.0", "1.2.3", "2.0.0"]);
+
+    let ref r = req("~0.24");
+    // Match >= 0.24.0, < 0.25.0-0
+    assert_prerelease_match_all(r, &["0.24.0", "0.24.1-pre", "0.24.1", "0.24.9"]);
+    // Not Match < 0.24.0
+    assert_prerelease_match_none(r, &["0.0.1", "0.9.9", "0.24.0-pre"]);
+    // Not Match >= 0.25.0-0
+    assert_prerelease_match_none(r, &["0.25.0-0", "1.1.0", "1.2.3", "2.0.0"]);
+
+    let ref r = req("~1");
+    // Match >= 1.0.0, < 1.1.0-0
+    assert_prerelease_match_all(r, &["1.0.0", "1.0.1-pre", "1.0.1", "1.0.9"]);
+    // Not Match < 1.0.0
+    assert_prerelease_match_none(r, &["0.0.1", "0.9.9", "1.0.0-pre"]);
+    // Not Match >= 1.1.0-0
+    assert_prerelease_match_none(r, &["1.1.0-0", "1.1.0", "1.2.3", "2.0.0"]);
+
+    let ref r = req("~1.2");
+    // Match >= 1.2.0, < 1.3.0-0
+    assert_prerelease_match_all(r, &["1.2.0", "1.2.1", "1.2.2-pre", "1.2.9"]);
+    // Not Match < 1.2.0
+    assert_prerelease_match_none(r, &["0.0.1", "1.0.0-pre", "1.1.0-0", "1.1.0"]);
+    // Not Match >= 1.3.0-0
+    assert_prerelease_match_none(r, &["1.3.0-0", "1.3.0", "1.4.3-pre", "1.8.9", "2.0.0"]);
+
+    let ref r = req("~1.2.3");
+    // Match >= 1.2.3, < 1.3.0-0
+    assert_prerelease_match_all(r, &["1.2.3", "1.2.4-pre", "1.2.4"]);
+    // Not Match < 1.2.3
+    assert_prerelease_match_none(r, &["0.0.1", "1.0.0-pre", "1.1.0-0", "1.1.0"]);
+    // Not Match >= 1.3.0-0
+    assert_prerelease_match_none(r, &["1.3.0-0", "1.3.0", "1.3.1-0", "1.3.1", "2.0.0"]);
+
+    let ref r = req("~1.2.3-0");
+    // Match >= 1.2.3-0, < 1.3.0-0
+    assert_prerelease_match_all(r, &["1.2.3-0", "1.2.3", "1.2.4-pre", "1.2.4"]);
+    // Not Match < 1.2.3-0
+    assert_prerelease_match_none(r, &["0.0.1", "1.0.0-pre", "1.1.0-0", "1.1.0"]);
+    // Not Match >= 1.3.0-0
+    assert_prerelease_match_none(r, &["1.3.0-0", "1.3.0", "1.3.1-0", "1.3.1", "2.0.0"]);
+}
+
+#[test]
+fn test_range() {
+    let ref r = req(">=1.0.0");
     assert_prerelease_match_all(r, &["1.0.0", "1.0.1-pre", "2.0.0-0", "2.0.0"]);
     assert_prerelease_match_none(r, &["0.9.9", "0.10.0", "1.0.0-pre.0"]);
 
-    let ref r: VersionReq = req(">=1.0.0-pre.1");
+    let ref r = req(">=1.0.0-pre.1");
     assert_prerelease_match_all(r, &["1.0.0-pre.1", "1.0.0", "1.0.1-pre", "2.0.0-0"]);
     assert_prerelease_match_none(r, &["0.9.9", "0.10.0", "1.0.0-pre.0"]);
 
-    let ref r: VersionReq = req("<=1.0.0");
+    let ref r = req("<=1.0.0");
     assert_prerelease_match_all(r, &["0.9.9", "0.10.0", "1.0.0-pre", "1.0.0"]);
     assert_prerelease_match_none(r, &["1.0.1", "1.0.1-pre", "1.1.0", "2.0.0-0"]);
 
-    let ref r: VersionReq = req("<=1.0.0-0");
+    let ref r = req("<=1.0.0-0");
     assert_prerelease_match_all(r, &["0.9.9", "0.1.0", "0.10.0", "1.0.0-0"]);
     assert_prerelease_match_none(r, &["1.0.0-pre", "1.0.1-pre", "1.1.0", "2.0.0-0"]);
 
-    let ref r: VersionReq = req(">1.0.0-0,<=1.1.0-0");
+    let ref r = req(">1.0.0-0,<=1.1.0-0");
     assert_prerelease_match_all(r, &["1.0.0-pre", "1.0.0", "1.0.9", "1.1.0-0"]);
     assert_prerelease_match_none(r, &["0.0.1", "1.0.0-0", "1.2.3-pre", "2.0.0"]);
 
-    let ref r: VersionReq = req(">=1.0.0,<1.1.0-0");
+    let ref r = req(">=1.0.0,<1.1.0-0");
     assert_prerelease_match_all(r, &["1.0.0", "1.0.0", "1.0.9"]);
     assert_prerelease_match_none(r, &["0.0.1", "1.0.0-pre", "1.1.0-0", "1.1.0", "2.0.0"]);
+}
+
+#[test]
+fn test_range_partial() {
+    let ref r = req(">=0.24");
+    assert_prerelease_match_all(r, &["0.24.0", "0.24.1", "2.0.0-0", "2.0.0"]);
+    assert_prerelease_match_none(r, &["0.9.9", "0.10.0", "0.24.0-pre.0"]);
+
+    let ref r = req(">=1");
+    assert_prerelease_match_all(r, &["1.0.0", "1.0.1-pre", "2.0.0-0", "2.0.0"]);
+    assert_prerelease_match_none(r, &["0.9.9", "0.10.0", "1.0.0-pre.0"]);
+
+    let ref r = req("<1");
+    assert_prerelease_match_none(r, &["1.0.0", "1.0.1-pre", "2.0.0-0", "2.0.0"]);
+    assert_prerelease_match_all(r, &["0.9.9", "0.10.0", "1.0.0-pre.0"]);
+
+    let ref r = req(">=1.1");
+    assert_prerelease_match_all(r, &["1.1.0", "1.1.1-pre", "2.0.0-0"]);
+    assert_prerelease_match_none(r, &["0.9.9", "0.10.0", "1.0.0-pre.0"]);
+
+    let ref r = req("<1.1");
+    assert_prerelease_match_none(r, &["1.1.0", "1.1.1-pre", "2.0.0-0"]);
+    assert_prerelease_match_all(r, &["0.9.9", "0.10.0", "1.0.0-pre.0"]);
+
+    let ref r = req(">1,<=1.1");
+    assert_prerelease_match_all(r, &["1.0.9", "1.1.0-0"]);
+    assert_prerelease_match_none(r, &["0.0.1", "1.0.0-0", "1.2.3-pre", "2.0.0"]);
+
+    let ref r = req(">=1.1,<2");
+    assert_prerelease_match_all(r, &["1.1.0", "1.2.9-pre", "1.2.9", "2.0.0-pre"]);
+    assert_prerelease_match_none(r, &["0.0.1", "1.0.0-pre", "1.1.0-pre"]);
+
+    let ref r = req("*");
+    assert_prerelease_match_all(r, &["0.0.1", "1.0.0", "1.2.9", "2.0.0-pre"]);
 }

--- a/tests/test_matches_prerelease.rs
+++ b/tests/test_matches_prerelease.rs
@@ -1,0 +1,109 @@
+#![cfg(not(test_node_semver))]
+#![allow(
+    clippy::missing_panics_doc,
+    clippy::shadow_unrelated,
+    clippy::toplevel_ref_arg,
+    clippy::wildcard_imports
+)]
+
+mod util;
+
+use crate::util::*;
+
+use semver::VersionReq;
+#[cfg_attr(not(no_track_caller), track_caller)]
+fn assert_prerelease_match_all(req: &VersionReq, versions: &[&str]) {
+    for string in versions {
+        let parsed = version(string);
+        assert!(req.matches_prerelease(&parsed), "did not match {}", string);
+    }
+}
+
+#[cfg_attr(not(no_track_caller), track_caller)]
+fn assert_prerelease_match_none(req: &VersionReq, versions: &[&str]) {
+    for string in versions {
+        let parsed = version(string);
+        assert!(!req.matches_prerelease(&parsed), "matched {}", string);
+    }
+}
+
+#[test]
+fn patch_caret() {
+    let ref r = req("0.0.7");
+    // Match >=0.0.7, <0.0.8-0, that's only match 0.0.7
+    assert_prerelease_match_all(r, &["0.0.7"]);
+    // Not Match <0.7.0
+    assert_prerelease_match_none(r, &["0.0.6", "0.0.7-0", "0.0.7-pre"]);
+    // Not Match >=0.8.0-0
+    assert_prerelease_match_none(r, &["0.0.8-0", "0.0.8-pre.1", "0.0.8"]);
+
+    let ref r = req("0.0.7-0");
+    // Match >=0.0.7-0, <0.0.8-0
+    assert_prerelease_match_all(r, &["0.0.7-0", "0.0.7-pre", "0.0.7"]);
+    // Not Match <0.7.0-0
+    assert_prerelease_match_none(r, &["0.0.6-0", "0.0.6-pre", "0.0.6"]);
+    // Not Match >=0.0.8-0
+    assert_prerelease_match_none(r, &["0.0.8-0", "0.0.8-pre.1", "0.0.8"]);
+}
+
+#[test]
+fn minor_caret() {
+    let ref r = req("0.8.0");
+    // Match >=0.8.0, <0.9.0-0
+    assert_prerelease_match_all(r, &["0.8.0", "0.8.1-0", "0.8.1-pre", "0.8.1"]);
+    // Not Match <0.8.0
+    assert_prerelease_match_none(r, &["0.1.0", "0.8.0-pre"]);
+    // Not Match >=0.9.0
+
+    let ref r = req("0.8.0-0");
+    // Match >=0.8.0-0, <0.9.0-0
+    assert_prerelease_match_all(r, &["0.8.0-0", "0.8.0", "0.8.1-pre", "0.8.1"]);
+    // Not Match <0.8.0-0
+    assert_prerelease_match_none(r, &["0.1.0", "0.7.7-pre", "0.7.7"]);
+    // Not Match >=0.9.0
+    assert_prerelease_match_none(r, &["0.9.0-0", "0.9.0", "1.0.0-pre", "2.0.0-0"]);
+}
+
+#[test]
+fn major_caret() {
+    let ref r = req("1.2.3");
+    // Match >=1.2.3, <2.0.0-0
+    assert_prerelease_match_all(r, &["1.2.3", "1.2.4-0", "1.2.4", "1.8.8"]);
+    // Not Match < 1.2.3
+    assert_prerelease_match_none(r, &["0.8.8", "1.2.0", "1.2.3-pre"]);
+    // Not Match >= 2.0.0-0
+    assert_prerelease_match_none(r, &["2.0.0-0", "2.0.0", "2.0.1"]);
+
+    let ref r = req("1.2.3-0");
+    // Match >=1.2.3-0, <2.0.0-0
+    assert_prerelease_match_all(r, &["1.2.3-pre", "1.2.3", "1.2.4-0", "1.2.4"]);
+    // Not Match < 1.2.3-0, >= 2.0.0-0
+    assert_prerelease_match_none(r, &["1.2.0", "2.0.0-0", "2.0.0"]);
+}
+
+#[test]
+fn test_non_caret() {
+    let ref r: VersionReq = req(">=1.0.0");
+    assert_prerelease_match_all(r, &["1.0.0", "1.0.1-pre", "2.0.0-0", "2.0.0"]);
+    assert_prerelease_match_none(r, &["0.9.9", "0.10.0", "1.0.0-pre.0"]);
+
+    let ref r: VersionReq = req(">=1.0.0-pre.1");
+    assert_prerelease_match_all(r, &["1.0.0-pre.1", "1.0.0", "1.0.1-pre", "2.0.0-0"]);
+    assert_prerelease_match_none(r, &["0.9.9", "0.10.0", "1.0.0-pre.0"]);
+
+    let ref r: VersionReq = req("<=1.0.0");
+    assert_prerelease_match_all(r, &["0.9.9", "0.10.0", "1.0.0-pre", "1.0.0"]);
+    assert_prerelease_match_none(r, &["1.0.1", "1.0.1-pre", "1.1.0", "2.0.0-0"]);
+
+    let ref r: VersionReq = req("<=1.0.0-0");
+    assert_prerelease_match_all(r, &["0.9.9", "0.1.0", "0.10.0", "1.0.0-0"]);
+    assert_prerelease_match_none(r, &["1.0.0-pre", "1.0.1-pre", "1.1.0", "2.0.0-0"]);
+
+    let ref r: VersionReq = req(">1.0.0-0,<=1.1.0-0");
+    assert_prerelease_match_all(r, &["1.0.0-pre", "1.0.0", "1.0.9", "1.1.0-0"]);
+    assert_prerelease_match_none(r, &["0.0.1", "1.0.0-0", "1.2.3-pre", "2.0.0"]);
+
+    let ref r: VersionReq = req(">=1.0.0,<1.1.0-0");
+    assert_prerelease_match_all(r, &["1.0.0", "1.0.0", "1.0.9"]);
+    assert_prerelease_match_none(r, &["0.0.1", "1.0.0-pre", "1.1.0-0", "1.1.0", "2.0.0"]);
+}

--- a/tests/test_matches_prerelease.rs
+++ b/tests/test_matches_prerelease.rs
@@ -1,4 +1,3 @@
-#![cfg(not(test_node_semver))]
 #![allow(
     clippy::missing_panics_doc,
     clippy::shadow_unrelated,
@@ -6,16 +5,23 @@
     clippy::wildcard_imports
 )]
 
+mod node;
 mod util;
-
 use crate::util::*;
-
+#[cfg(test_node_semver)]
+use node::{req, VersionReq};
+#[cfg(not(test_node_semver))]
 use semver::VersionReq;
 #[cfg_attr(not(no_track_caller), track_caller)]
 fn assert_prerelease_match_all(req: &VersionReq, versions: &[&str]) {
     for string in versions {
         let parsed = version(string);
-        assert!(req.matches_prerelease(&parsed), "did not match {}", string);
+        assert!(
+            req.matches_prerelease(&parsed),
+            "{} did not match {}",
+            req,
+            string,
+        );
     }
 }
 
@@ -23,303 +29,430 @@ fn assert_prerelease_match_all(req: &VersionReq, versions: &[&str]) {
 fn assert_prerelease_match_none(req: &VersionReq, versions: &[&str]) {
     for string in versions {
         let parsed = version(string);
-        assert!(!req.matches_prerelease(&parsed), "matched {}", string);
+        assert!(
+            !req.matches_prerelease(&parsed),
+            "{} matched {}",
+            req,
+            string
+        );
     }
 }
 
 #[test]
-fn patch_caret() {
-    let ref r = req("0.0.7");
-    // Match >=0.0.7, <0.0.8-0, that's only match 0.0.7
-    assert_prerelease_match_all(r, &["0.0.7"]);
-    // Not Match <0.7.0
-    assert_prerelease_match_none(r, &["0.0.6", "0.0.7-0", "0.0.7-pre"]);
-    // Not Match >=0.8.0-0
-    assert_prerelease_match_none(r, &["0.0.8-0", "0.0.8-pre.1", "0.0.8"]);
-
-    let ref r = req("0.0.7-0");
-    // Match >=0.0.7-0, <0.0.8-0
-    assert_prerelease_match_all(r, &["0.0.7-0", "0.0.7-pre", "0.0.7"]);
-    // Not Match <0.7.0-0
-    assert_prerelease_match_none(r, &["0.0.6-0", "0.0.6-pre", "0.0.6"]);
-    // Not Match >=0.0.8-0
-    assert_prerelease_match_none(r, &["0.0.8-0", "0.0.8-pre.1", "0.0.8"]);
-}
-
-#[test]
-fn minor_caret() {
-    let ref r = req("0.24");
-    // Match >= 0.24.0, < 0.25.0-0
-    assert_prerelease_match_all(r, &["0.24.0", "0.24.1-0", "0.24.1-pre", "0.24.1"]);
-    // Not Match < 0.24.0
-    assert_prerelease_match_none(r, &["0.1.0", "0.8.0-pre"]);
-    // Not Match >= 0.25.0-0
-    assert_prerelease_match_none(r, &["0.25.0-0", "0.25.0", "0.25.8", "2.0.0-0"]);
-
-    let ref r = req("0.8.0");
-    // Match >= 0.8.0, < 0.9.0-0
-    assert_prerelease_match_all(r, &["0.8.0", "0.8.1-0", "0.8.1-pre", "0.8.1"]);
-    // Not Match <0.8.0
-    assert_prerelease_match_none(r, &["0.1.0", "0.8.0-pre"]);
-    // Not Match >=0.9.0-0
-    assert_prerelease_match_none(r, &["0.9.0-0", "1.0.0-pre", "2.0.0-0"]);
-
-    let ref r = req("0.8.0-0");
-    // Match >= 0.8.0-0, < 0.9.0-0
-    assert_prerelease_match_all(r, &["0.8.0-0", "0.8.0", "0.8.1-pre", "0.8.1"]);
-    // Not Match < 0.8.0-0
-    assert_prerelease_match_none(r, &["0.1.0", "0.7.7-pre", "0.7.7"]);
-    // Not Match >= 0.9.0-0
-    assert_prerelease_match_none(r, &["0.9.0-0", "0.9.0", "1.0.0-pre", "2.0.0-0"]);
-}
-
-#[test]
-fn major_caret() {
-    let ref r = req("0");
-    // Match >= 0.0.0, < 1.0.0-0
-    assert_prerelease_match_all(r, &["0.0.0", "0.0.1-0", "0.0.1-pre", "0.1.1"]);
-    // Not Match < 0.0.0
-    assert_prerelease_match_none(r, &["0.0.0-pre"]);
-    // Not Match >= 1.0.0-0
-    assert_prerelease_match_none(r, &["1.0.0-0", "1.0.0", "1.0.1-pre", "2.0.0-0"]);
-
-    let ref r = req("0.0");
-    // Match >= 0.0.0, < 0.1.0-0
-    assert_prerelease_match_all(r, &["0.0.1-z0", "0.0.9"]);
-    // Not Match >= 0.1.0-0
-    assert_prerelease_match_none(r, &["0.1.0-0", "0.1.0", "0.1.1-pre", "0.1.1-z0", "1.1.0"]);
-
-    let ref r = req("0.0.0");
-    // Match >= 0.0.0, < 0.0.1-0
-    assert_prerelease_match_all(r, &["0.0.0"]);
-    // Not Match >= 0.0.1-0
-    assert_prerelease_match_none(r, &["0.0.1-0", "0.0.1", "1.0.1-pre"]);
-
-    let ref r = req("1");
-    // Match >= 1.0.0, < 2.0.0-0
-    assert_prerelease_match_all(r, &["1.2.3", "1.2.4-0", "1.2.4", "1.8.8"]);
-    // Not Match < 1.0.0
-    assert_prerelease_match_none(r, &["0.0.8", "0.9.0", "1.0.0-pre"]);
-    // Not Match >= 2.0.0-0
-    assert_prerelease_match_none(r, &["2.0.0-0", "2.0.0", "2.0.1"]);
-
-    let ref r = req("1.2");
-    // Match >= 1.2.0, < 1.3.0-0
-    assert_prerelease_match_all(r, &["1.2.3", "1.2.4-0", "1.2.4", "1.8.8"]);
-    // Not Match < 1.2.0
-    assert_prerelease_match_none(r, &["0.0.8", "0.9.0", "1.0.0-pre"]);
-    // Not Match >= 1.3.0-0
-    assert_prerelease_match_none(r, &["2.0.0-0", "2.0.0", "2.0.1"]);
-
-    let ref r = req("1.2.3");
-    // Match >=1.2.3, < 2.0.0-0
-    assert_prerelease_match_all(r, &["1.2.3", "1.2.4-0", "1.2.4", "1.8.8"]);
-    // Not Match < 1.2.3
-    assert_prerelease_match_none(r, &["0.8.8", "1.2.0", "1.2.3-pre"]);
-    // Not Match >= 2.0.0-0
-    assert_prerelease_match_none(r, &["2.0.0-0", "2.0.0", "2.0.1"]);
-
-    let ref r = req("1.2.3-0");
-    // Match >= 1.2.3-0, < 2.0.0-0
-    assert_prerelease_match_all(r, &["1.2.3-pre", "1.2.3", "1.2.4-0", "1.2.4"]);
-    // Not Match < 1.2.3-0, >= 2.0.0-0
-    assert_prerelease_match_none(r, &["1.2.0", "2.0.0-0", "2.0.0"]);
-}
-
-#[test]
+#[cfg(not(any(feature = "mirror_node_matches_prerelease", test_node_semver)))]
 fn test_exact() {
-    // =I.J.K equivalent to >=I.J.K, <I.J.(K+1)-0
-    let ref r = req("=4.2.1");
-    assert_prerelease_match_all(r, &["4.2.1"]);
-    assert_prerelease_match_none(r, &["1.2.3", "4.2.1-pre", "4.2.2", "5.0.0"]);
-
-    // =I.J equivalent to >=I.J.0, <I.(J+1).0-0
-    let ref r = req("=4.2");
-    // Match >= 4.2.0, < 4.3.0-0
-    assert_prerelease_match_all(r, &["4.2.0", "4.2.1", "4.2.4-pre", "4.2.9"]);
-    // Not Match < 4.2.0
-    assert_prerelease_match_none(r, &["0.0.1", "2.1.2-pre", "4.0.0-pre"]);
-    // Not Match >= 4.3.0-0
-    assert_prerelease_match_none(r, &["4.3.0-0", "4.3.0", "5.0.0-0", "5.0.0"]);
-
-    // =I equivalent to >=I.0.0, <(I+1).0.0-0
-    let ref r = req("=4");
-    // Match >= 4.0.0, < 5.0.0-0
-    assert_prerelease_match_all(r, &["4.0.0", "4.2.1", "4.2.4-pre", "4.9.9"]);
-    // Not Match < 4.0.0
-    assert_prerelease_match_none(r, &["0.0.1", "2.1.2-pre", "4.0.0-pre"]);
-    // Not Match >= 5.0.0-0
-    assert_prerelease_match_none(r, &["5.0.0-0", "5.0.0", "5.0.1"]);
-
     // =I.J.K-pre only match I.J.K-pre
     let ref r = req("=4.2.1-0");
     // Only exactly match 4.2.1-0
     assert_prerelease_match_all(r, &["4.2.1-0"]);
     // Not match others
-    assert_prerelease_match_none(r, &["1.2.3", "4.2.0", "4.2.1-1", "4.2.2", "4.3.5"]);
+    assert_prerelease_match_none(r, &["1.2.3", "4.2.0", "4.2.1-1", "4.2.2"]);
+
+    // =I.J.K equivalent to >=I.J.K, <I.J.(K+1)-0
+    for r in &[req("=4.2.1"), req(">=4.2.1, <4.2.2-0")] {
+        assert_prerelease_match_all(r, &["4.2.1"]);
+        assert_prerelease_match_none(r, &["1.2.3", "4.2.1-0", "4.2.2-0", "4.2.2"]);
+    }
+
+    // =I.J equivalent to >=I.J.0, <I.(J+1).0-0
+    for r in &[req("=4.2"), req(">=4.2.0, <4.3.0-0")] {
+        assert_prerelease_match_all(r, &["4.2.0", "4.2.1", "4.2.9"]);
+        assert_prerelease_match_none(r, &["0.0.1", "2.1.2-0", "4.2.0-0"]);
+        assert_prerelease_match_none(r, &["4.3.0-0", "4.3.0", "5.0.0-0", "5.0.0"]);
+    }
+
+    // =I equivalent to >=I.0.0, <(I+1).0.0-0
+    for r in &[req("=4"), req(">=4.0.0, <5.0.0-0")] {
+        assert_prerelease_match_all(r, &["4.0.0", "4.2.1", "4.2.4-0", "4.9.9"]);
+        assert_prerelease_match_none(r, &["0.0.1", "2.1.2-0", "4.0.0-0"]);
+        assert_prerelease_match_none(r, &["5.0.0-0", "5.0.0", "5.0.1"]);
+    }
 }
+
+#[test]
+#[cfg(not(any(feature = "mirror_node_matches_prerelease", test_node_semver)))]
+fn test_greater_eq() {
+    // >=I.J.K-0
+    let ref r = req(">=4.2.1-0");
+    assert_prerelease_match_all(r, &["4.2.1-0", "4.2.1", "5.0.0"]);
+    assert_prerelease_match_none(r, &["0.0.0", "1.2.3"]);
+
+    // >=I.J.K
+    let ref r = req(">=4.2.1");
+    assert_prerelease_match_all(r, &["4.2.1", "5.0.0"]);
+    assert_prerelease_match_none(r, &["0.0.0", "4.2.1-0"]);
+
+    // >=I.J equivalent to >=I.J.0
+    for r in &[req(">=4.2"), req(">=4.2.0")] {
+        assert_prerelease_match_all(r, &["4.2.1-0", "4.2.0", "4.3.0"]);
+        assert_prerelease_match_none(r, &["0.0.0", "4.1.1", "4.2.0-0"]);
+    }
+
+    // >=I equivalent to >=I.0.0
+    for r in &[req(">=4"), req(">=4.0.0")] {
+        assert_prerelease_match_all(r, &["4.0.0", "4.1.0-1", "5.0.0"]);
+        assert_prerelease_match_none(r, &["0.0.0", "1.2.3", "4.0.0-0"]);
+    }
+}
+
+#[test]
+#[cfg(not(any(feature = "mirror_node_matches_prerelease", test_node_semver)))]
+fn test_less() {
+    // <I.J.K-0
+    let ref r = req("<4.2.1-0");
+    assert_prerelease_match_all(r, &["0.0.0", "4.0.0"]);
+    assert_prerelease_match_none(r, &["4.2.1-0", "4.2.2", "5.0.0-0", "5.0.0"]);
+
+    // <I.J.K
+    let ref r = req("<4.2.1");
+    assert_prerelease_match_all(r, &["0.0.0", "4.0.0", "4.2.1-0"]);
+    assert_prerelease_match_none(r, &["4.2.2", "5.0.0-0", "5.0.0"]);
+
+    // <I.J equivalent to <I.J.0
+    for r in &[req("<4.2"), req("<4.2.0")] {
+        assert_prerelease_match_all(r, &["0.0.0", "4.1.0", "4.2.0-0"]);
+        assert_prerelease_match_none(r, &["4.2.0", "4.3.0-0", "4.3.0"]);
+    }
+
+    // <I equivalent to <I.0.0
+    for r in &[req("<4"), req("<4.0.0")] {
+        assert_prerelease_match_all(r, &["0.0.0", "4.0.0-0"]);
+        assert_prerelease_match_none(r, &["4.0.0", "5.0.0-1", "5.0.0"]);
+    }
+}
+
+#[test]
+#[cfg(not(any(feature = "mirror_node_matches_prerelease", test_node_semver)))]
+fn test_caret() {
+    // ^I.J.K.0 (for I>0) — equivalent to >=I.J.K-0, <(I+1).0.0-0
+    for r in &[req("^1.2.3-0"), req(">=1.2.3-0, <2.0.0-0")] {
+        assert_prerelease_match_all(r, &["1.2.3-0", "1.2.3-1", "1.2.3", "1.9.9"]);
+        assert_prerelease_match_none(r, &["0.0.9", "1.1.1-0", "2.0.0-0", "2.1.1"]);
+    }
+
+    // ^I.J.K (for I>0) — equivalent to >=I.J.K, <(I+1).0.0-0
+    for r in &[req("^1.2.3"), req(">=1.2.3, <2.0.0-0")] {
+        assert_prerelease_match_all(r, &["1.2.3", "1.9.9"]);
+        assert_prerelease_match_none(
+            r,
+            &["0.0.9", "1.1.1-0", "1.2.3-0", "1.2.3-1", "2.0.0-0", "2.1.1"],
+        );
+    }
+
+    // ^0.J.K-0 (for J>0) — equivalent to >=0.J.K-0, <0.(J+1).0-0
+    for r in &[req("^0.2.3-0"), req(">=0.2.3-0, <0.3.0-0")] {
+        assert_prerelease_match_all(r, &["0.2.3-0", "0.2.3", "0.2.9-0", "0.2.9"]);
+        assert_prerelease_match_none(r, &["0.0.9", "0.3.0-0", "0.3.11", "1.1.1"]);
+    }
+
+    // ^0.J.K (for J>0) — equivalent to >=0.J.K-0, <0.(J+1).0-0
+    for r in &[req("^0.2.3"), req(">=0.2.3, <0.3.0-0")] {
+        assert_prerelease_match_all(r, &["0.2.3", "0.2.9-0", "0.2.9"]);
+        assert_prerelease_match_none(r, &["0.0.9", "0.2.3-0", "0.3.0-0", "0.3.11", "1.1.1"]);
+    }
+
+    // ^0.0.K-0 — equivalent to >=0.0.K-0, <0.0.(K+1)-0
+    for r in &[req("^0.0.3-0"), req(">=0.0.3-0, <0.1.0-0")] {
+        assert_prerelease_match_all(r, &["0.0.3-0", "0.0.3-1", "0.0.3"]);
+        assert_prerelease_match_none(r, &["0.0.1", "0.3.0-0", "0.4.0-0", "1.1.1"]);
+    }
+
+    // ^0.0.K — equivalent to >=0.0.K, <0.0.(K+1)-0
+    for r in &[req("^0.0.3"), req(">=0.0.3, <0.1.0-0")] {
+        assert_prerelease_match_all(r, &["0.0.3"]);
+        assert_prerelease_match_none(
+            r,
+            &["0.0.1", "0.0.3-0", "0.3.0-0", "0.0.3-1", "0.4.0-0", "1.1.1"],
+        );
+    }
+
+    // ^I.J (for I>0 or J>0) — equivalent to >=I.J.0, <(I+1).0.0-0)
+    for r in &[req("^1.2"), req(">=1.2.0, <2.0.0-0")] {
+        assert_prerelease_match_all(r, &["1.2.0", "1.9.0-0", "1.9.9"]);
+        assert_prerelease_match_none(r, &["0.0.1", "0.0.4-0", "1.2.0-0", "2.0.0-0", "4.0.1"]);
+    }
+
+    // ^0.0 — equivalent to >=0.0.0, <0.1.0-0
+    for r in &[req("^0.0"), req(">=0.0.0, <0.1.0-0")] {
+        assert_prerelease_match_all(r, &["0.0.0", "0.0.1", "0.0.4-0"]);
+        assert_prerelease_match_none(r, &["0.0.0-0", "0.1.0-0", "0.1.0", "1.1.1"]);
+    }
+
+    // ^I — equivalent to >=I.0.0, <(I+1).0.0-0
+    for r in &[req("^1"), req(">=1.0.0, <2.0.0-0")] {
+        assert_prerelease_match_all(r, &["1.0.0", "1.0.1"]);
+        assert_prerelease_match_none(r, &["0.1.0-0", "0.1.0", "1.0.0-0", "2.0.0-0", "3.1.2"]);
+    }
+}
+
+#[test]
+#[cfg(not(any(feature = "mirror_node_matches_prerelease", test_node_semver)))]
+fn test_wildcard() {
+    // I.J.* — equivalent to =I.J
+    //
+    // =I.J equivalent to >=I.J.0, <I.(J+1).0-0
+    for r in &[req("4.2.*"), req("=4.2")] {
+        // Match >= 4.2.0, < 4.3.0-0
+        assert_prerelease_match_all(r, &["4.2.0", "4.2.1", "4.2.9"]);
+        // Not Match < 4.2.0
+        assert_prerelease_match_none(r, &["0.0.1", "2.1.2-0", "4.2.0-0"]);
+        // Not Match >= 4.3.0-0
+        assert_prerelease_match_none(r, &["4.3.0-0", "4.3.0", "5.0.0", "5.0.1"]);
+    }
+
+    // I.* or I.*.* — equivalent to =I
+    //
+    // =I equivalent to >=I.0.0, <(I+1).0.0-0
+    for r in &[req("4.*"), req("4.*.*"), req("=4")] {
+        // Match >= 4.0.0, < 5.0.0-0
+        assert_prerelease_match_all(r, &["4.0.0", "4.2.1", "4.9.9"]);
+        // Not Match < 4.0.0
+        assert_prerelease_match_none(r, &["0.0.1", "2.1.2-0", "4.0.0-0"]);
+        // Not Match >= 5.0.0-0
+        assert_prerelease_match_none(r, &["5.0.0-0", "5.0.0", "5.0.1"]);
+    }
+}
+
+//
+// These tests below can pass in both implementations
+//
 
 #[test]
 fn test_greater() {
+    // >I.J.K-0
+    let ref r = req(">4.2.1-0");
+    assert_prerelease_match_all(r, &["4.2.1", "4.2.2", "5.0.0"]);
+    assert_prerelease_match_none(r, &["0.0.0", "4.2.1-0"]);
+
     // >I.J.K
     let ref r = req(">4.2.1");
     assert_prerelease_match_all(r, &["4.2.2", "5.0.0-0", "5.0.0"]);
-    assert_prerelease_match_none(r, &["0.0.0", "4.2.1-pre", "4.2.1"]);
+    assert_prerelease_match_none(r, &["0.0.0", "4.2.1-0", "4.2.1"]);
+
     // >I.J equivalent to >=I.(J+1).0-0
-    let ref r = req(">4.2");
-    assert_prerelease_match_all(r, &["4.3.0-pre", "4.3.0", "5.0.0"]);
-    assert_prerelease_match_none(r, &["0.0.0", "4.2.1"]);
+    for r in &[req(">4.2"), req(">=4.3.0-0")] {
+        assert_prerelease_match_all(r, &["4.3.0-0", "4.3.0", "5.0.0"]);
+        assert_prerelease_match_none(r, &["0.0.0", "4.2.1"]);
+    }
+
     // >I equivalent to >=(I+1).0.0-0
-    let ref r = req(">4");
-    assert_prerelease_match_all(r, &["5.0.0-0", "5.0.0-1", "5.0.0"]);
-    assert_prerelease_match_none(r, &["0.0.0", "4.2.1"]);
-}
-
-#[test]
-fn test_greater_eq() {
-    // >=I.J.K
-    let ref r = req(">=4.2.1");
-    assert_prerelease_match_all(r, &["4.2.1", "5.0.0-0", "5.0.0"]);
-    assert_prerelease_match_none(r, &["0.0.0", "4.2.1-pre"]);
-    // >=I.J equivalent to >=I.J.0
-    let ref r = req(">=4.2");
-    assert_prerelease_match_all(r, &["4.2.0", "4.2.1-pre", "4.3.0", "5.0.0"]);
-    assert_prerelease_match_none(r, &["0.0.0", "4.1.1", "4.2.0-0"]);
-    // >=I equivalent to >=I.0.0
-    let ref r = req(">=4");
-    assert_prerelease_match_all(r, &["4.0.0", "4.1.0-1", "5.0.0"]);
-    assert_prerelease_match_none(r, &["0.0.0", "4.0.0-pre"]);
-}
-
-#[test]
-fn test_less() {
-    // <I.J.K
-    let ref r = req("<4.2.1");
-    assert_prerelease_match_all(r, &["0.0.0", "4.0.0", "4.2.1-pre"]);
-    assert_prerelease_match_none(r, &["4.2.2", "5.0.0-0", "5.0.0"]);
-    // <I.J equivalent to <I.J.0
-    let ref r = req("<4.2");
-    assert_prerelease_match_all(r, &["0.0.0", "4.2.0-pre"]);
-    assert_prerelease_match_none(r, &["4.2.0", "4.3.0-pre", "4.3.0"]);
-    // <I equivalent to <I.0.0
-    let ref r = req("<4");
-    assert_prerelease_match_all(r, &["0.0.0", "4.0.0-pre"]);
-    assert_prerelease_match_none(r, &["4.0.0", "5.0.0-1", "5.0.0"]);
+    for r in &[req(">4"), req(">=5.0.0-0")] {
+        assert_prerelease_match_all(r, &["5.0.0-0", "5.0.0"]);
+        assert_prerelease_match_none(r, &["0.0.0", "4.2.1"]);
+    }
 }
 
 #[test]
 fn test_less_eq() {
     // <=I.J.K
     let ref r = req("<=4.2.1");
-    assert_prerelease_match_all(r, &["0.0.0", "4.2.1-pre", "4.2.1"]);
+    assert_prerelease_match_all(r, &["0.0.0", "4.2.1-0", "4.2.1"]);
     assert_prerelease_match_none(r, &["4.2.2", "5.0.0-0", "5.0.0"]);
+    // <=I.J.K-0
+    let ref r = req("<=4.2.1-0");
+    assert_prerelease_match_all(r, &["0.0.0", "4.2.1-0"]);
+    assert_prerelease_match_none(r, &["4.2.1", "4.2.2", "5.0.0-0", "5.0.0"]);
+
     // <=I.J equivalent to <I.(J+1).0-0
-    let ref r = req("<=4.2");
-    assert_prerelease_match_all(r, &["0.0.0", "4.2.0-pre"]);
-    assert_prerelease_match_none(r, &["4.3.0-0", "4.3.0", "4.4.0"]);
+    for r in &[req("<=4.2"), req("<4.3.0-0")] {
+        assert_prerelease_match_all(r, &["0.0.0", "4.2.0-0"]);
+        assert_prerelease_match_none(r, &["4.3.0-0", "4.3.0", "4.4.0"]);
+    }
+
     // <=I equivalent to <(I+1).0.0-0
-    let ref r = req("<=4");
-    assert_prerelease_match_all(r, &["0.0.0", "4.0.0-pre", "4.0.0"]);
-    assert_prerelease_match_none(r, &["5.0.0-1", "5.0.0"]);
+    for r in &[req("<=4"), req("<5.0.0-0")] {
+        assert_prerelease_match_all(r, &["0.0.0", "4.0.0-0", "4.0.0"]);
+        assert_prerelease_match_none(r, &["5.0.0-1", "5.0.0"]);
+    }
 }
 
 #[test]
 fn test_tilde() {
+    // ~I.J.K-0 — equivalent to >=I.J.K-0, <I.(J+1).0-0
+    for r in &[req("~1.2.3-0"), req(">= 1.2.3-0, < 1.3.0-0")] {
+        assert_prerelease_match_all(r, &["1.2.3-0", "1.2.3", "1.2.4-0", "1.2.4"]);
+        assert_prerelease_match_none(r, &["0.0.1", "1.1.0-0"]);
+        assert_prerelease_match_none(r, &["1.3.0-0", "1.3.0", "1.3.1", "2.0.0"]);
+    }
+
     // ~I.J.K — equivalent to >=I.J.K, <I.(J+1).0-0
-    let ref r = req("~1.2.3");
-    // Match >= 1.2.3, < 1.3.0-0
-    assert_prerelease_match_all(r, &["1.2.3", "1.2.4-pre", "1.2.4"]);
-    // Not Match < 1.2.3
-    assert_prerelease_match_none(r, &["0.0.1", "1.0.0-pre", "1.1.0-0", "1.1.0"]);
-    // Not Match >= 1.3.0-0
-    assert_prerelease_match_none(r, &["1.3.0-0", "1.3.0", "1.3.1-0", "1.3.1", "2.0.0"]);
+    for r in &[req("~1.2.3"), req(">= 1.2.3, < 1.3.0-0")] {
+        assert_prerelease_match_all(r, &["1.2.3", "1.2.4-0", "1.2.4"]);
+        assert_prerelease_match_none(r, &["0.0.1", "1.1.0-0", "1.2.3-0"]);
+        assert_prerelease_match_none(r, &["1.3.0-0", "1.3.0", "1.3.1", "2.0.0"]);
+    }
 
     // ~I.J — equivalent to >=I.J.0, <I.(J+1).0-0
-    let ref r = req("~0.24");
-    // Match >= 0.24.0, < 0.25.0-0
-    assert_prerelease_match_all(r, &["0.24.0", "0.24.1-pre", "0.24.1", "0.24.9"]);
-    // Not Match < 0.24.0
-    assert_prerelease_match_none(r, &["0.0.1", "0.9.9", "0.24.0-pre"]);
-    // Not Match >= 0.25.0-0
-    assert_prerelease_match_none(r, &["0.25.0-0", "1.1.0", "1.2.3", "2.0.0"]);
+    for r in &[req("~0.24"), req(">=0.24.0, <0.25.0-0")] {
+        assert_prerelease_match_all(r, &["0.24.0", "0.24.1-0", "0.24.1", "0.24.9"]);
+        assert_prerelease_match_none(r, &["0.0.1", "0.9.9", "0.24.0-0"]);
+        assert_prerelease_match_none(r, &["0.25.0-0", "1.1.0", "1.2.3", "2.0.0"]);
+    }
 
     // ~I — >=I.0.0, <(I+1).0.0-0
-    let ref r = req("~1");
-    // Match >= 1.0.0, < 2.0.0-0
-    assert_prerelease_match_all(r, &["1.0.0", "1.1.0-0", "1.1.0", "1.2.3"]);
-    // Not Match < 1.0.0
-    assert_prerelease_match_none(r, &["0.0.1", "0.9.9", "1.0.0-pre"]);
-    // Not Match >= 2.0.0-0
-    assert_prerelease_match_none(r, &["2.0.0-0", "2.0.0", "2.0.1"]);
+    for r in &[req("~1"), req(">=1.0.0, <2.0.0-0")] {
+        assert_prerelease_match_all(r, &["1.0.0", "1.1.0-0", "1.1.0"]);
+        assert_prerelease_match_none(r, &["0.0.1", "0.9.9", "1.0.0-0"]);
+        assert_prerelease_match_none(r, &["2.0.0-0", "2.0.0", "2.0.1"]);
+    }
+}
 
-    // ~I.J.K-[pre] — equivalent to >=I.J.K-[pre], <I.J.(K+1).0
-    let ref r = req("~1.2.3-0");
-    // Match >= 1.2.3-0, < 1.3.0-0
-    assert_prerelease_match_all(r, &["1.2.3-0", "1.2.3", "1.2.4-pre", "1.2.4"]);
-    // Not Match < 1.2.3-0
-    assert_prerelease_match_none(r, &["0.0.1", "1.0.0-pre", "1.1.0-0", "1.1.0"]);
-    // Not Match >= 1.3.0-0
-    assert_prerelease_match_none(r, &["1.3.0-0", "1.3.0", "1.3.1-0", "1.3.1", "2.0.0"]);
+//
+// These tests below are for node semver compatibility test. (with includePrerelease=true, see https://github.com/npm/node-semver?tab=readme-ov-file#functions)
+//
+
+#[test]
+#[cfg(any(feature = "mirror_node_matches_prerelease", test_node_semver))]
+fn test_exact() {
+    // =I.J.K-pre only match I.J.K-pre
+    let ref r = req("=4.2.1-0");
+    // Only exactly match 4.2.1-0
+    assert_prerelease_match_all(r, &["4.2.1-0"]);
+    // Not match others
+    assert_prerelease_match_none(r, &["1.2.3", "4.2.0", "4.2.1-1", "4.2.2"]);
+
+    // =I.J.K equivalent to >=I.J.K, <I.J.(K+1)-0
+    for r in &[req("=4.2.1"), req(">=4.2.1, <4.2.2-0")] {
+        assert_prerelease_match_all(r, &["4.2.1"]);
+        assert_prerelease_match_none(r, &["1.2.3", "4.2.1-0", "4.2.2-0", "4.2.2"]);
+    }
+
+    // =I.J equivalent to >=I.J.0-0, <I.(J+1).0-0
+    for r in &[req("=4.2"), req(">=4.2.0-0, <4.3.0-0")] {
+        assert_prerelease_match_all(r, &["4.2.0-0", "4.2.0", "4.2.1", "4.2.9"]);
+        assert_prerelease_match_none(r, &["0.0.1", "2.1.2-0"]);
+        assert_prerelease_match_none(r, &["4.3.0-0", "4.3.0", "5.0.0-0", "5.0.0"]);
+    }
+
+    // =I equivalent to >=I.0.0-0, <(I+1).0.0-0
+    for r in &[req("=4"), req(">=4.0.0-0, <5.0.0-0")] {
+        assert_prerelease_match_all(r, &["4.0.0-0", "4.0.0", "4.2.1", "4.2.4-0", "4.9.9"]);
+        assert_prerelease_match_none(r, &["0.0.1", "2.1.2-0"]);
+        assert_prerelease_match_none(r, &["5.0.0-0", "5.0.0", "5.0.1"]);
+    }
 }
 
 #[test]
+#[cfg(any(feature = "mirror_node_matches_prerelease", test_node_semver))]
+fn test_greater_eq() {
+    // >=I.J.K-0
+    let ref r = req(">=4.2.1-0");
+    assert_prerelease_match_all(r, &["4.2.1-0", "4.2.1", "5.0.0"]);
+    assert_prerelease_match_none(r, &["0.0.0", "1.2.3"]);
+
+    // >=I.J.K
+    let ref r = req(">=4.2.1");
+    assert_prerelease_match_all(r, &["4.2.1", "5.0.0"]);
+    assert_prerelease_match_none(r, &["0.0.0", "4.2.1-0"]);
+
+    // >=I.J equivalent to >=I.J.0-0
+    for r in &[req(">=4.2"), req(">=4.2.0-0")] {
+        assert_prerelease_match_all(r, &["4.2.0-0", "4.2.0", "4.2.1-0", "4.3.0"]);
+        assert_prerelease_match_none(r, &["0.0.0", "4.1.1"]);
+    }
+
+    // >=I equivalent to >=I.0.0-0
+    for r in &[req(">=4"), req(">=4.0.0-0")] {
+        assert_prerelease_match_all(r, &["4.0.0-0", "4.0.0", "4.1.0-1", "5.0.0"]);
+        assert_prerelease_match_none(r, &["0.0.0", "1.2.3"]);
+    }
+}
+
+#[test]
+#[cfg(any(feature = "mirror_node_matches_prerelease", test_node_semver))]
+fn test_less() {
+    // <I.J.K-0
+    let ref r = req("<4.2.1-0");
+    assert_prerelease_match_all(r, &["0.0.0", "4.0.0"]);
+    assert_prerelease_match_none(r, &["4.2.1-0", "4.2.2", "5.0.0-0", "5.0.0"]);
+
+    // <I.J.K
+    let ref r = req("<4.2.1");
+    assert_prerelease_match_all(r, &["0.0.0", "4.0.0", "4.2.1-0"]);
+    assert_prerelease_match_none(r, &["4.2.2", "5.0.0-0", "5.0.0"]);
+
+    // <I.J equivalent to <I.J.0-0
+    for r in &[req("<4.2"), req("<4.2.0-0")] {
+        assert_prerelease_match_all(r, &["0.0.0", "4.1.0"]);
+        assert_prerelease_match_none(r, &["4.2.0-0", "4.2.0", "4.3.0-0", "4.3.0"]);
+    }
+
+    // <I equivalent to <I.0.0-0
+    for r in &[req("<4"), req("<4.0.0-0")] {
+        assert_prerelease_match_all(r, &["0.0.0"]);
+        assert_prerelease_match_none(r, &["4.0.0-0", "4.0.0", "5.0.0-1", "5.0.0"]);
+    }
+}
+
+#[test]
+#[cfg(any(feature = "mirror_node_matches_prerelease", test_node_semver))]
 fn test_caret() {
+    // ^I.J.K.0 (for I>0) — equivalent to >=I.J.K-0, <(I+1).0.0-0
+    for r in &[req("^1.2.3-0"), req(">=1.2.3-0, <2.0.0-0")] {
+        assert_prerelease_match_all(r, &["1.2.3-0", "1.2.3-1", "1.2.3", "1.9.9"]);
+        assert_prerelease_match_none(r, &["0.0.9", "1.1.1-0", "2.0.0-0", "2.1.1"]);
+    }
+
     // ^I.J.K (for I>0) — equivalent to >=I.J.K, <(I+1).0.0-0
-    let ref r = req("^1.2.3");
-    assert_prerelease_match_all(r, &["1.2.3", "1.2.4-0", "1.8.9"]);
-    assert_prerelease_match_none(r, &["0.0.9", "1.1.1-0", "1.2.3-0", "2.0.0-pre", "2.1.1"]);
+    for r in &[req("^1.2.3"), req(">=1.2.3, <2.0.0-0")] {
+        assert_prerelease_match_all(r, &["1.2.3", "1.9.9"]);
+        assert_prerelease_match_none(
+            r,
+            &["0.0.9", "1.1.1-0", "1.2.3-0", "1.2.3-1", "2.0.0-0", "2.1.1"],
+        );
+    }
 
-    // ^0.J.K (for J>0) — equivalent to >=0.J.K, <0.(J+1).0-0
-    let ref r = req("^0.2.3");
-    assert_prerelease_match_all(r, &["0.2.3", "0.2.9-0", "0.2.9"]);
-    assert_prerelease_match_none(r, &["0.0.9", "0.2.3-0", "0.3.0-0", "0.3.11", "1.1.1"]);
+    // ^0.J.K-0 (for J>0) — equivalent to >=0.J.K-0, <0.(J+1).0-0
+    // ^0.J.K (for J>0) — equivalent to >=0.J.K-0, <0.(J+1).0-0
+    for r in &[req("^0.2.3-0"), req("^0.2.3"), req(">=0.2.3-0, <0.3.0-0")] {
+        assert_prerelease_match_all(r, &["0.2.3-0", "0.2.3", "0.2.9-0", "0.2.9"]);
+        assert_prerelease_match_none(r, &["0.0.9", "0.3.0-0", "0.3.11", "1.1.1"]);
+    }
 
-    // ^0.0.K — equivalent to >=0.0.K, <0.0.(K+1)-0
-    let ref r = req("^0.0.3");
-    assert_prerelease_match_all(r, &["0.0.3"]);
-    assert_prerelease_match_none(
-        r,
-        &["0.0.1", "0.0.4-0", "0.0.9", "0.3.0-0", "0.4.0-0", "1.1.1"],
-    );
+    // ^0.0.K-0 — equivalent to >=0.0.K-0, <0.0.(K+1)-0
+    // ^0.0.K — equivalent to >=0.0.K-0, <0.0.(K+1)-0
+    for r in &[req("^0.0.3-0"), req("^0.0.3"), req(">=0.0.3-0, <0.1.0-0")] {
+        assert_prerelease_match_all(r, &["0.0.3-0", "0.0.3-1", "0.0.3"]);
+        assert_prerelease_match_none(r, &["0.0.1", "0.3.0-0", "0.4.0-0", "1.1.1"]);
+    }
 
-    // ^I.J (for I>0 or J>0) — equivalent to >=I.J.0, <(I+1).0.0-0)
-    let ref r = req("^1.2");
-    assert_prerelease_match_all(r, &["1.2.0", "1.9.0-0", "1.9.9"]);
-    assert_prerelease_match_none(r, &["0.0.1", "0.0.4-0", "1.2.0-0", "2.0.0-0", "4.0.1"]);
+    // ^I.J (for I>0 or J>0) — equivalent to >=I.J.0-0, <(I+1).0.0-0)
+    for r in &[req("^1.2"), req(">=1.2.0-0, <2.0.0-0")] {
+        assert_prerelease_match_all(r, &["1.2.0-0", "1.2.0", "1.9.0-0", "1.9.9"]);
+        assert_prerelease_match_none(r, &["0.0.1", "0.0.4-0", "2.0.0-0", "4.0.1"]);
+    }
 
-    // ^0.0 — equivalent to >=0.0.0, <0.1.0-0
-    let ref r = req("^0.0");
-    assert_prerelease_match_all(r, &["0.0.0", "0.0.1", "0.0.4-0"]);
-    assert_prerelease_match_none(r, &["0.1.0-0", "0.1.0", "1.1.1"]);
+    // ^0.0 — equivalent to >=0.0.0-0, <0.1.0-0
+    for r in &[req("^0.0"), req(">=0.0.0-0, <0.1.0-0")] {
+        assert_prerelease_match_all(r, &["0.0.0-0", "0.0.0", "0.0.1", "0.0.4-0"]);
+        assert_prerelease_match_none(r, &["0.1.0-0", "0.1.0", "1.1.1"]);
+    }
 
-    // ^I — equivalent to >=I.0.0, <(I+1).0.0-0
-    let ref r = req("^1");
-    assert_prerelease_match_all(r, &["1.0.0", "1.0.1", "1.0.4-0"]);
-    assert_prerelease_match_none(r, &["0.1.0-0", "0.1.0", "2.0.0-0", "3.1.2"]);
+    // ^I — equivalent to >=I.0.0-0, <(I+1).0.0-0
+    for r in &[req("^1"), req(">=1.0.0-0, <2.0.0-0")] {
+        assert_prerelease_match_all(r, &["1.0.0-0", "1.0.0", "1.0.1"]);
+        assert_prerelease_match_none(r, &["0.1.0-0", "0.1.0", "2.0.0-0", "3.1.2"]);
+    }
 }
 
 #[test]
+#[cfg(any(feature = "mirror_node_matches_prerelease", test_node_semver))]
 fn test_wildcard() {
     // I.J.* — equivalent to =I.J
     //
-    // =I.J equivalent to >=I.J.0, <I.(J+1).0-0
-    let ref r = req("4.2.*");
-    // Match >= 4.2.0, < 4.3.0-0
-    assert_prerelease_match_all(r, &["4.2.0", "4.2.1", "4.2.4-pre", "4.2.9"]);
-    // Not Match < 4.2.0
-    assert_prerelease_match_none(r, &["0.0.1", "2.1.2-pre", "4.0.0-pre"]);
-    // Not Match >= 4.3.0-0
-    assert_prerelease_match_none(r, &["4.3.0-0", "4.3.0", "5.0.0-0", "5.0.0", "5.0.1"]);
+    // =I.J equivalent to >=I.J.0-0, <I.(J+1).0-0
+    for r in &[req("4.2.*"), req("=4.2")] {
+        assert_prerelease_match_all(r, &["4.2.0-0", "4.2.0", "4.2.1", "4.2.9"]);
+        assert_prerelease_match_none(r, &["0.0.1", "2.1.2-0"]);
+        assert_prerelease_match_none(r, &["4.3.0-0", "4.3.0", "5.0.0", "5.0.1"]);
+    }
 
     // I.* or I.*.* — equivalent to =I
     //
-    // =I equivalent to >=I.0.0, <(I+1).0.0-0
-    for r in &[req("4.*"), req("4.*.*")] {
-        // Match >= 4.0.0, < 5.0.0-0
-        assert_prerelease_match_all(r, &["4.0.0", "4.2.1", "4.2.4-pre", "4.9.9"]);
-        // Not Match < 4.0.0
-        assert_prerelease_match_none(r, &["0.0.1", "2.1.2-pre", "4.0.0-pre"]);
-        // Not Match >= 5.0.0-0
+    // =I equivalent to >=I.0.0-0, <(I+1).0.0-0
+    for r in &[req("4.*"), req("4.*.*"), req("=4")] {
+        assert_prerelease_match_all(r, &["4.0.0-0", "4.0.0", "4.2.1", "4.9.9"]);
+        assert_prerelease_match_none(r, &["0.0.1", "2.1.2-0"]);
         assert_prerelease_match_none(r, &["5.0.0-0", "5.0.0", "5.0.1"]);
     }
 }

--- a/tests/test_matches_prerelease.rs
+++ b/tests/test_matches_prerelease.rs
@@ -75,9 +75,6 @@ fn minor_caret() {
 
 #[test]
 fn major_caret() {
-    let ref r = req("=0.0.0-r");
-    assert_prerelease_match_all(r, &["0.0.0"]);
-
     let ref r = req("0");
     // Match >= 0.0.0, < 1.0.0-0
     assert_prerelease_match_all(r, &["0.0.0", "0.0.1-0", "0.0.1-pre", "0.1.1"]);
@@ -269,12 +266,10 @@ fn test_exact() {
     assert_prerelease_match_none(r, &["1.2.3", "4.2.1-pre", "4.2.2", "5.0.0"]);
 
     let ref r = req("=4.2.1-0");
-    // Match >= 4.2.1-0 < 4.2.2-0
-    assert_prerelease_match_all(r, &["4.2.1-0", "4.2.1-1", "4.2.1-pre"]);
-    // Not Match < 4.2.1-0
-    assert_prerelease_match_none(r, &["1.2.3", "4.2.0"]);
-    // Not Match >= 4.2.2-0
-    assert_prerelease_match_none(r, &["4.2.2-0", "4.2.2", "4.3.5", "6.8.9"]);
+    // Only exactly match 4.2.1-0
+    assert_prerelease_match_all(r, &["4.2.1-0"]);
+    // Not match others
+    assert_prerelease_match_none(r, &["1.2.3", "4.2.0", "4.2.1-1", "4.2.2", "4.3.5"]);
 
     // Speicial Case
     let ref r = req("=0");


### PR DESCRIPTION
## What 's this PR want to solve?

The main purpose is to solve the `upper bound semantic` approved by  [rfc#precise-pre-release-cargo-update](https://github.com/rust-lang/rfcs/pull/3493)

it extends the matching mechanism of the pre-release version, 

```
So before,

1.2.3  -> ^1.2.3 -> >=1.2.3, <2.0.0 (with implicit holes excluding pre-release versions)
would become

1.2.3  -> ^1.2.3 -> >=1.2.3, <2.0.0-0
Note that the old syntax implicitly excluded 2.0.0-<prerelease> which we have have to explicitly exclude by referencing the smallest possible pre-release version of -0.
```

If this PR could be merged, it maybe fixed the `cargo update --precise <pre-release>` [upper bound semantic](https://github.com/rust-lang/cargo/issues/13290#issuecomment-2149628751)
