### PR TITLE
Faster Ord when Eq

### DIFF
--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -257,12 +257,18 @@ impl Drop for Identifier {
     }
 }
 
+impl Identifier {
+    pub(crate) fn ptr_eq(&self, rhs: &Self) -> bool {
+        self.head == rhs.head && self.tail == rhs.tail
+    }
+}
+
 impl PartialEq for Identifier {
     fn eq(&self, rhs: &Self) -> bool {
-        if self.is_empty_or_inline() {
+        if self.ptr_eq(rhs) {
             // Fast path (most common)
-            self.head == rhs.head && self.tail == rhs.tail
-        } else if rhs.is_empty_or_inline() {
+            true
+        } else if self.is_empty_or_inline() || rhs.is_empty_or_inline() {
             false
         } else {
             // SAFETY: both reprs are in the heap allocated representation.

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -50,8 +50,10 @@ impl PartialOrd for BuildMetadata {
 
 impl Ord for Prerelease {
     fn cmp(&self, rhs: &Self) -> Ordering {
+        if self.identifier.ptr_eq(&rhs.identifier) {
+            return Ordering::Equal;
+        }
         match self.is_empty() {
-            true if rhs.is_empty() => return Ordering::Equal,
             // A real release compares greater than prerelease.
             true => return Ordering::Greater,
             // Prerelease compares less than the real release.
@@ -105,6 +107,9 @@ impl Ord for Prerelease {
 
 impl Ord for BuildMetadata {
     fn cmp(&self, rhs: &Self) -> Ordering {
+        if self.identifier.ptr_eq(&rhs.identifier) {
+            return Ordering::Equal;
+        }
         let lhs = self.as_str().split('.');
         let mut rhs = rhs.as_str().split('.');
 


### PR DESCRIPTION
I have [a tool](https://github.com/Eh2406/pubgrub-crates-benchmark) for benchmarking Cargoes resolver and a new PubGrub based resolver. Both resolvers spend a lot of time  checking whether two `Versions`  are equal using `Ord`. For example, `.contains` on a `BTreeMap<Versions, ...`. @arielb1 pointed out that adding a fast path makes a big  difference in the runtime of the resolvers. On master the program reports `PubGrub CPU time: 86.97min, Cargo CPU time: 190.67min`, with this PR `PubGrub CPU time: 71.33min, Cargo CPU time: 167.92min`. (For posterity the command is `cargo r -r -- -t 100` running commit `9dc991f94c45688a6d2d90d29532c5d96fd064b3`) there is about +/- 3 min  of run-to-run variability.

In most cases `Prerelease` and `BuildMetadata` are empty. `Prerelease` already did not do much work for the `empty == empty` case,  most of the time difference therefore comes from `BuildMetadata`.

I also considered a simpler
```rust
if self.identifier.is_empty() && rhs.identifier.is_empty() {
    return Ordering::Equal;
}
```
Which is not as big an improvement (`PubGrub CPU time: 75.85min`).

Other variations that get approximately the same  result, at least within the margin of error are:
```rust
if self.identifier == rhs.identifier {
    return Ordering::Equal;
}
```
or 
```rust
if self.identifier.as_str().as_ptr() == rhs.identifier.as_str().as_ptr() {
    return Ordering::Equal;
}
```

What are your thoughts about this optimization? Which variation would you prefer? Is there some testing you would like added?