### PR TITLE
feat(Version): implement Default trait and is_empty()

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,6 +1,6 @@
 use crate::backport::*;
 use crate::identifier::Identifier;
-use crate::{BuildMetadata, Comparator, Prerelease, VersionReq};
+use crate::{BuildMetadata, Comparator, Prerelease, Version, VersionReq};
 use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
 use core::iter::FromIterator;
@@ -149,6 +149,12 @@ impl Ord for BuildMetadata {
         } else {
             Ordering::Less
         }
+    }
+}
+
+impl Default for Version {
+    fn default() -> Self {
+        Version::new(0, 0, 0) // is_empty() -> true
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -478,6 +478,26 @@ impl Version {
             &(other.major, other.minor, other.patch, &other.pre),
         )
     }
+
+    /// The default version 0.0.0 is considered empty (if pre is empty too).
+    /// Build metadata may exist.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use semver::Version;
+    ///
+    /// assert_eq!(Version::default().is_empty(), true);
+    /// assert_eq!(Version::parse("0.0.0").unwrap().is_empty(), true);
+    /// assert_eq!(Version::parse("0.0.0+c7fcc0e").unwrap().is_empty(), true);
+    /// assert_eq!(Version::parse("0.0.0-alpha.1").unwrap().is_empty(), false);
+    /// assert_eq!(Version::parse("0.0.1").unwrap().is_empty(), false);
+    /// assert_eq!(Version::parse("0.1.0").unwrap().is_empty(), false);
+    /// assert_eq!(Version::parse("1.0.0").unwrap().is_empty(), false);
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.major == 0 && self.minor == 0 && self.patch == 0 && self.pre.is_empty()
+    }
 }
 
 impl VersionReq {

--- a/tests/test_version.rs
+++ b/tests/test_version.rs
@@ -179,6 +179,22 @@ fn test_display() {
 }
 
 #[test]
+fn test_default() {
+    assert_to_string(version("0.0.0"), "0.0.0");
+    assert_to_string(Version::default(), "0.0.0");
+    assert_eq!(Version::default(), version("0.0.0"));
+}
+
+#[test]
+fn test_is_empty() {
+    assert_eq!(Version::default().is_empty(), true);
+    assert_eq!(version("0.0.0").is_empty(), true);
+    assert_eq!(version("0.0.0+build.42").is_empty(), true);
+    assert_eq!(version("0.0.0-alpha1").is_empty(), false);
+    assert_eq!(version("0.0.1").is_empty(), false);
+}
+
+#[test]
 fn test_lt() {
     assert!(version("0.0.0") < version("1.2.3-alpha2"));
     assert!(version("1.0.0") < version("1.2.3-alpha2"));


### PR DESCRIPTION
### Feature
- Version::default() `0.0.0` allows adding semver to structs deriving from Default trait
- Version.is_empty() shows if the default has been used (true for `0.0.0+build`, false for `0.0.0-rc`)