### PR TITLE
Delete no_const_vec_new configuration

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,19 +11,12 @@ fn main() {
     };
 
     if compiler >= 80 {
-        println!("cargo:rustc-check-cfg=cfg(no_const_vec_new)");
         println!("cargo:rustc-check-cfg=cfg(no_non_exhaustive)");
         println!("cargo:rustc-check-cfg=cfg(no_nonzero_bitscan)");
         println!("cargo:rustc-check-cfg=cfg(no_str_strip_prefix)");
         println!("cargo:rustc-check-cfg=cfg(no_track_caller)");
         println!("cargo:rustc-check-cfg=cfg(no_unsafe_op_in_unsafe_fn_lint)");
         println!("cargo:rustc-check-cfg=cfg(test_node_semver)");
-    }
-
-    if compiler < 39 {
-        // const Vec::new.
-        // https://doc.rust-lang.org/std/vec/struct.Vec.html#method.new
-        println!("cargo:rustc-cfg=no_const_vec_new");
     }
 
     if compiler < 40 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,6 @@ pub struct Version {
 ///   not permitted within a partial version, i.e. anywhere between the major
 ///   version number and its minor, patch, pre-release, or build metadata.
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
-#[cfg_attr(no_const_vec_new, derive(Default))]
 pub struct VersionReq {
     pub comparators: Vec<Comparator>,
 }
@@ -496,7 +495,6 @@ impl VersionReq {
     /// pre-release component. Since `*` is not written with an explicit major,
     /// minor, and patch version, and does not contain a nonempty pre-release
     /// component, it does not match any pre-release versions.
-    #[cfg(not(no_const_vec_new))] // rustc <1.39
     pub const STAR: Self = VersionReq {
         comparators: Vec::new(),
     };
@@ -528,7 +526,6 @@ impl VersionReq {
 }
 
 /// The default VersionReq is the same as [`VersionReq::STAR`].
-#[cfg(not(no_const_vec_new))]
 impl Default for VersionReq {
     fn default() -> Self {
         VersionReq::STAR

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -89,12 +89,7 @@ impl FromStr for VersionReq {
         if let Some((ch, text)) = wildcard(text) {
             let rest = text.trim_start_matches(' ');
             if rest.is_empty() {
-                #[cfg(not(no_const_vec_new))]
                 return Ok(VersionReq::STAR);
-                #[cfg(no_const_vec_new)] // rustc <1.39
-                return Ok(VersionReq {
-                    comparators: Vec::new(),
-                });
             } else if rest.starts_with(',') {
                 return Err(Error::new(ErrorKind::WildcardNotTheOnlyComparator(ch)));
             } else {

--- a/tests/test_version_req.rs
+++ b/tests/test_version_req.rs
@@ -43,7 +43,6 @@ fn test_basic() {
 }
 
 #[test]
-#[cfg(not(no_const_vec_new))]
 fn test_default() {
     let ref r = VersionReq::default();
     assert_eq!(r, &VersionReq::STAR);
@@ -320,12 +319,7 @@ pub fn test_logical_or() {
 
 #[test]
 pub fn test_any() {
-    #[cfg(not(no_const_vec_new))]
     let ref r = VersionReq::STAR;
-    #[cfg(no_const_vec_new)]
-    let ref r = VersionReq {
-        comparators: Vec::new(),
-    };
     assert_match_all(r, &["0.0.1", "0.1.0", "1.0.0"]);
 }
 


### PR DESCRIPTION
Unneeded since https://github.com/dtolnay/semver/pull/334.