### PR TITLE
Delete no_unsafe_op_in_unsafe_fn_lint configuration

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -12,14 +12,7 @@ fn main() {
 
     if compiler >= 80 {
         println!("cargo:rustc-check-cfg=cfg(no_nonzero_bitscan)");
-        println!("cargo:rustc-check-cfg=cfg(no_unsafe_op_in_unsafe_fn_lint)");
         println!("cargo:rustc-check-cfg=cfg(test_node_semver)");
-    }
-
-    if compiler < 52 {
-        // #![deny(unsafe_op_in_unsafe_fn)].
-        // https://github.com/rust-lang/rust/issues/71668
-        println!("cargo:rustc-cfg=no_unsafe_op_in_unsafe_fn_lint");
     }
 
     if compiler < 53 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,8 +63,7 @@
 #![doc(html_root_url = "https://docs.rs/semver/1.0.26")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(no_unsafe_op_in_unsafe_fn_lint), deny(unsafe_op_in_unsafe_fn))]
-#![cfg_attr(no_unsafe_op_in_unsafe_fn_lint, allow(unused_unsafe))]
+#![deny(unsafe_op_in_unsafe_fn)]
 #![allow(
     clippy::cast_lossless,
     clippy::cast_possible_truncation,


### PR DESCRIPTION
Unneeded since https://github.com/dtolnay/semver/pull/334.